### PR TITLE
Return actual vote count, not count of result rows

### DIFF
--- a/www_admin/votesystem.inc.php
+++ b/www_admin/votesystem.inc.php
@@ -27,8 +27,8 @@ class VoteRange extends Vote
   }
   function GetVoteCount()
   {
-    $v = SQLLib::selectRows(sprintf_esc("SELECT COUNT(DISTINCT userid) FROM votes_range"));
-    return count($v);
+    $v = SQLLib::selectRow(sprintf_esc("SELECT COUNT(DISTINCT userid) AS votecount FROM votes_range"));
+    return $v->votecount;
   }
   function SaveVotes()
   {


### PR DESCRIPTION
Fix a bug in GetVoteCount() that causes vote count to always display as
one (i.e., the number of rows in the sql query): read the row data
instead which already represents the count of distinct voters.

This fixes 918e629 (Fix a MySQL 5.7 incompatibility).