### PR TITLE
Add support for PHP 7 with default php.ini (short_open_tag=Off)

### DIFF
--- a/www_admin/.gitignore
+++ b/www_admin/.gitignore
@@ -1,0 +1,6 @@
+.htaccess
+.htpasswd
+.oplock
+activeplugins.serialize
+database.inc.php
+noscreenshot-*.png

--- a/www_admin/beamer.php
+++ b/www_admin/beamer.php
@@ -115,7 +115,7 @@ if ($_POST["mode"])
 }
 printf("<h2>Change beamer setting</h2>\n");
 
-$f = file_get_contents("result.xml");
+$f = @file_get_contents("result.xml");
 preg_match("|\\<mode\\>(.*)\\</mode\\>|m",$f,$m);
 
 $s = SQLLib::selectRows("select * from compos order by start");

--- a/www_admin/beamer.php
+++ b/www_admin/beamer.php
@@ -1,6 +1,6 @@
-<?
+<?php
 include_once("header.inc.php");
-if ($_POST["mode"]) 
+if ($_POST["mode"])
 {
   ob_start();
 
@@ -9,12 +9,12 @@ if ($_POST["mode"])
   printf("  <mode>%s</mode>\n",$_POST["mode"]);
 
   switch ($_POST["mode"]) {
-    case "announcement": 
+    case "announcement":
     {
       $isHTML = $_POST["isHTML"] == "on" ? "true" : "false";
       printf("  <announcementtext isHTML='%s'>%s</announcementtext>\n",$isHTML,_html($_POST["announcement"]));
     } break;
-    case "compocountdown": 
+    case "compocountdown":
     {
       if ($_POST["compo"])
       {
@@ -27,23 +27,23 @@ if ($_POST["mode"])
         printf("  <eventname>%s</eventname>\n",_html( $_POST["eventname"] ));
         printf("  <compostart>%s</compostart>\n",_html( $_POST["eventtime"] ));
       }
-      
+
     } break;
-    case "compodisplay": 
+    case "compodisplay":
     {
       $compo = get_compo( $_POST["compo"] );
       printf("  <componame>%s</componame>\n",_html($compo->name));
       printf("  <entries>\n");
-      
+
       $query = new SQLSelect();
       $query->AddTable("compoentries");
       $query->AddWhere(sprintf_esc("compoid=%d",$_POST["compo"]));
       $query->AddOrder("playingorder");
       run_hook("admin_beamer_generate_compodisplay_dbquery",array("query"=>&$query));
       $entries = SQLLib::selectRows( $query->GetQuery() );
-      
+
       $playingorder = 1;
-      foreach ($entries as $t) 
+      foreach ($entries as $t)
       {
         printf("    <entry>\n");
         printf("      <number>%d</number>\n",$playingorder++);
@@ -55,21 +55,21 @@ if ($_POST["mode"])
       }
       printf("  </entries>\n");
     } break;
-    case "prizegiving": 
+    case "prizegiving":
     {
       $voter = SpawnVotingSystem();
-      
+
       if (!$voter)
         die("VOTING SYSTEM ERROR");
-    
+
       $compo = get_compo( $_POST["compo"] );
-    
+
       $query = new SQLSelect();
       $query->AddTable("compoentries");
       $query->AddWhere(sprintf_esc("compoid=%d",$_POST["compo"]));
       run_hook("admin_beamer_generate_prizegiving_dbquery",array("query"=>&$query));
       $entries = SQLLib::selectRows( $query->GetQuery() );
-    
+
       global $results;
       $results = array();
       $results = $voter->CreateResultsFromVotes( $compo, $entries );
@@ -84,7 +84,7 @@ if ($_POST["mode"])
         if ($lastpoints != $v) $ranks++;
         $lastpoints = $v;
       }
-      
+
       $lastpoints = -1;
 
       printf("  <componame>%s</componame>\n",_html($compo->name));
@@ -141,10 +141,10 @@ printf("Current mode: <a href='result.xml'>%s</a>",$m[1]);
 <h3>Compo countdown</h3>
 <form action="beamer.php" method="post" enctype="multipart/form-data">
 <select name="compo">
-<?
+<?php
 foreach($s as $t)
   printf("  <option value='%d'>%s</option>\n",$t->id,$t->name);
-?>  
+?>
 </select><br/>
   <input type="hidden" name="mode" value="compocountdown"/>
   <input type="submit" value="Switch to Compo Countdown mode."/>
@@ -167,10 +167,10 @@ foreach($s as $t)
 <h3>Compo display</h3>
 <form action="beamer.php" method="post" enctype="multipart/form-data">
 <select name="compo">
-<?
+<?php
 foreach($s as $t)
   printf("  <option value='%d'>%s</option>\n",$t->id,$t->name);
-?>  
+?>
 </select><br/>
   <input type="hidden" name="mode" value="compodisplay"/>
   <input type="submit" value="Switch to Compo Display mode."/>
@@ -181,15 +181,15 @@ foreach($s as $t)
 <h3>Prizegiving</h3>
 <form action="beamer.php" method="post" enctype="multipart/form-data">
 <select name="compo">
-<?
+<?php
 foreach($s as $t)
   printf("  <option value='%d'>%s</option>\n",$t->id,$t->name);
-?>  
+?>
 </select><br/>
   <input type="hidden" name="mode" value="prizegiving"/>
   <input type="submit" value="Switch to Prizegiving mode."/>
 </form>
 </div>
-<?
+<?php
 include_once("footer.inc.php");
 ?>

--- a/www_admin/bootstrap.inc.php
+++ b/www_admin/bootstrap.inc.php
@@ -1,6 +1,6 @@
 <?php
 error_reporting(E_ALL ^ E_NOTICE);
-if (!defined(ADMIN_DIR))
+if (!defined("ADMIN_DIR"))
   include_once(dirname(__FILE__)."/database.inc.php");
 
 include_once(ADMIN_DIR."/sqllib.inc.php");

--- a/www_admin/bootstrap.inc.php
+++ b/www_admin/bootstrap.inc.php
@@ -1,8 +1,8 @@
-<?
+<?php
 error_reporting(E_ALL ^ E_NOTICE);
 if (!defined(ADMIN_DIR))
   include_once(dirname(__FILE__)."/database.inc.php");
-  
+
 include_once(ADMIN_DIR."/sqllib.inc.php");
 include_once(ADMIN_DIR."/setting.inc.php");
 include_once(ADMIN_DIR."/thumbnail.inc.php");

--- a/www_admin/cmsgen.inc.php
+++ b/www_admin/cmsgen.inc.php
@@ -1,7 +1,7 @@
-<?
+<?php
 function cmsProcessPost($formdata) {
   $mypost = array();
-  
+
   $qcb = get_magic_quotes_gpc() ? "stripslashes" : "nop";
 
   $mypost = $_POST;
@@ -13,14 +13,14 @@ function cmsProcessPost($formdata) {
     $sql = sprintf_esc("delete from %s where %s='%s'",$formdata["table"],$formdata["fields"][$formdata["key"]]["sqlfield"],$mypost["__cms_id"]);
     SQLLib::query($sql);
     return;
-  }  
+  }
   if ($mypost["__cms_deletefromeditform"]) {
     $sql = sprintf_esc("delete from %s where %s='%s'",$formdata["table"],$formdata["fields"][$formdata["key"]]["sqlfield"],$mypost["__cms_id"]);
     SQLLib::query($sql);
     return;
   }
   $sqlarray = array();
-  
+
   foreach($formdata["fields"] as $k=>$v) {
     if ($formdata["key"] == $k && !isset($mypost[$k])) continue;
     if ($v["dontinsert"]) continue;
@@ -35,33 +35,33 @@ function cmsProcessPost($formdata) {
             $mypost[$k."_h"],
             $mypost[$k."_i"],
             $mypost[$k."_s"]);
-      } break; 
+      } break;
       case "datetime_easy": {
         $sqlarray[$sqlname] =
           sprintf("%s %s",
             $mypost[$k."_date"],
             $mypost[$k."_time"]);
-      } break; 
+      } break;
       case "date": {
         $sqlarray[$sqlname] =
           sprintf("%04d-%02d-%02d",
             $mypost[$k."_y"],
             $mypost[$k."_m"],
             $mypost[$k."_d"]);
-      } break; 
+      } break;
       case "time": {
         $sqlarray[$sqlname] =
           sprintf("%02d:%02d:%02d",
             $mypost[$k."_h"],
             $mypost[$k."_i"],
             $mypost[$k."_s"]);
-      } break; 
+      } break;
       case "checkbox": {
         $sqlarray[$sqlname] = ($mypost[$k] == "on");
-      } break; 
+      } break;
       case "hex": {
         $sqlarray[$sqlname] = gmp_strval("0x0".$mypost[$k],10);
-      } break; 
+      } break;
       case "bitfield": {
         $n = gmp_init(0);
         if ($mypost[$k])
@@ -79,10 +79,10 @@ function cmsProcessPost($formdata) {
       default: {
 //        if ($mypost[$k])
           $sqlarray[$sqlname] = $mypost[$k];
-      } break; 
+      } break;
     }
   }
-  
+
 //  var_dump($sqlarray);
   if (isset($mypost["__cms_id"]) && !$mypost["__cms_insert"]) {
     $where = sprintf_esc("%s='%s'",$formdata["fields"][$formdata["key"]]["sqlfield"],$mypost["__cms_id"]);
@@ -97,8 +97,8 @@ function cmsRenderEditForm($formdata,$id,$insert = false) {
     $sql = sprintf_esc("select * from %s where %s='%s'",$formdata["table"],$formdata["fields"][$formdata["key"]]["sqlfield"],$id);
     $s = SQLLib::selectRow($sql);
   }
-  echo "<form action='".(($formdata["stayonform"]&&!$insert)?basename($_SERVER["REQUEST_URI"]):$formdata["processingfile"])."' method='post'>\n"; 
-  printf("<table class='%s edit'>\n",$formdata["class"]); 
+  echo "<form action='".(($formdata["stayonform"]&&!$insert)?basename($_SERVER["REQUEST_URI"]):$formdata["processingfile"])."' method='post'>\n";
+  printf("<table class='%s edit'>\n",$formdata["class"]);
   foreach($formdata["fields"] as $k=>$v) {
     $fieldname = $k;
     $sqlname = $v["sqlfield"];
@@ -264,7 +264,7 @@ function cmsRenderEditForm($formdata,$id,$insert = false) {
         printf("  <td><div class='columns2'><ul>\n");
 
         $value = gmp_init($s->$sqlname."");
-        
+
         foreach($v["fields"] as $k=>$v2) {
           $ander = gmp_init(0);
           gmp_setbit($ander,($k));
@@ -301,22 +301,22 @@ function cmsRenderEditForm($formdata,$id,$insert = false) {
       } break;
     }
   }
-  echo "<tr>\n"; 
-  printf(" <td colspan='2'>\n"); 
+  echo "<tr>\n";
+  printf(" <td colspan='2'>\n");
   if ($formdata["formid"])
-    printf("<input type='hidden' name='__cms_formid' value='%s' />\n",htmlspecialchars($formdata["formid"],ENT_QUOTES)); 
+    printf("<input type='hidden' name='__cms_formid' value='%s' />\n",htmlspecialchars($formdata["formid"],ENT_QUOTES));
   if ($id!==NULL && !$insert) {
-    printf("<input type='hidden' name='__cms_id' value='%s' />\n",htmlspecialchars($id,ENT_QUOTES)); 
-    printf("<input type='submit' name='__cms_edit' value='%s' />\n",htmlspecialchars("Save changes",ENT_QUOTES)); 
+    printf("<input type='hidden' name='__cms_id' value='%s' />\n",htmlspecialchars($id,ENT_QUOTES));
+    printf("<input type='submit' name='__cms_edit' value='%s' />\n",htmlspecialchars("Save changes",ENT_QUOTES));
     printf("<input type='submit' name='__cms_insert' value='%s' />\n",htmlspecialchars("Save as new",ENT_QUOTES));
-    printf("<input type='submit' name='__cms_deletefromeditform' value='%s' />\n",htmlspecialchars("Delete",ENT_QUOTES)); 
+    printf("<input type='submit' name='__cms_deletefromeditform' value='%s' />\n",htmlspecialchars("Delete",ENT_QUOTES));
   } else {
-    printf("<input type='submit' name='__cms_insert' value='%s' />\n",htmlspecialchars("Save as new",ENT_QUOTES)); 
+    printf("<input type='submit' name='__cms_insert' value='%s' />\n",htmlspecialchars("Save as new",ENT_QUOTES));
   }
-  printf("</td>\n"); 
-  echo "</tr>\n"; 
-  echo "</table>\n"; 
-  echo "</form>\n"; 
+  printf("</td>\n");
+  echo "</tr>\n";
+  echo "</table>\n";
+  echo "</form>\n";
 }
 
 function cmsRenderInsertForm($formdata) {
@@ -326,17 +326,17 @@ function cmsRenderInsertForm($formdata) {
 function cmsRenderDeleteForm($formdata,$id) {
   echo "<form action='".$formdata["processingfile"]."' method='post'>\n";
   echo "Are you sure you want to delete the record ".$id."?\n";
-  printf("<input type='hidden' name='__cms_id' value='%s' />\n",$id); 
-  printf("<input type='hidden' name='__cms_formid' value='%s' />\n",htmlspecialchars($formdata["formid"],ENT_QUOTES)); 
-  printf("<input type='submit' name='__cms_deleteconfirm' value='Yes' />\n"); 
-  printf("<input type='submit' name='__cms_canceldelete' value='No' />\n"); 
-  echo "</form>\n"; 
+  printf("<input type='hidden' name='__cms_id' value='%s' />\n",$id);
+  printf("<input type='hidden' name='__cms_formid' value='%s' />\n",htmlspecialchars($formdata["formid"],ENT_QUOTES));
+  printf("<input type='submit' name='__cms_deleteconfirm' value='Yes' />\n");
+  printf("<input type='submit' name='__cms_canceldelete' value='No' />\n");
+  echo "</form>\n";
 }
 
 function cmsRenderListGrid($formdata) {
   $c = SQLLib::selectRow(sprintf_esc("select count(*) as c from %s",$formdata["table"]));
   $numrow = $c->c;
-  
+
   $sql = sprintf_esc("select * from %s ",$formdata["table"]);
   if ($formdata["where"])  $sql .= sprintf_esc(" where (%s),",$formdata["where"]);
   if ($formdata["order"])  $sql .= sprintf_esc(" order by %s",$formdata["order"]);
@@ -344,9 +344,9 @@ function cmsRenderListGrid($formdata) {
   if ($formdata["offset"]) $sql .= sprintf_esc(" offset %s",$formdata["offset"]);
 
   $s = SQLLib::selectRows($sql);
-  printf("<table class='%s'>\n",$formdata["class"]); 
+  printf("<table class='%s'>\n",$formdata["class"]);
   printf("<tr>\n");
-  foreach($formdata["fields"] as $k=>$v) 
+  foreach($formdata["fields"] as $k=>$v)
     if ($v["grid"]) {
       if ($formdata["sortable"]) {
         if ($k == $formdata["order"]) {
@@ -355,22 +355,22 @@ function cmsRenderListGrid($formdata) {
           printf("<th><a href='%ssort=%s'>%s</a> &uArr;</th>\n",$formdata["processingfile"].(strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;"),$k,$v["caption"]);
         } else {
           printf("<th><a href='%ssort=%s'>%s</a></th>\n",$formdata["processingfile"].(strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;"),$k,$v["caption"]);
-        } 
+        }
       } else
         printf("<th>%s</th>\n",$v["caption"]);
-    }       
-  printf("<th colspan='2'>Operations</th>\n");       
+    }
+  printf("<th colspan='2'>Operations</th>\n");
   printf("</tr>\n");
   $n = 0;
   foreach($formdata["fields"] as $v)
     if ($v["grid"]) $n++;
-    
+
   printf("<tr>\n");
-  echo "  <td colspan='".($n+2)."'><a href='".$formdata["processingfile"].(strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;")."new=add'>Add new item</a></td>\n"; 
+  echo "  <td colspan='".($n+2)."'><a href='".$formdata["processingfile"].(strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;")."new=add'>Add new item</a></td>\n";
   printf("</tr>\n");
   $key = $formdata["fields"][$formdata["key"]]["sqlfield"];
   foreach($s as $row) {
-    echo "<tr>\n"; 
+    echo "<tr>\n";
     foreach($formdata["fields"] as $k=>$v) {
       if (!$v["grid"]) continue;
       $sf = $v["sqlfield"];
@@ -394,24 +394,24 @@ function cmsRenderListGrid($formdata) {
     //printf("<td><a href='%s?view=%s'>view</a></td>\n",$formdata["processingfile"],$row->$key);
     printf("<td><a href='%s%sedit=%s'>edit</a></td>\n",$formdata["processingfile"],strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;",$row->$key);
     printf("<td><a href='%s%sdel=%s'>del</a></td>\n"  ,$formdata["processingfile"],strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;",$row->$key);
-    echo "</tr>\n"; 
+    echo "</tr>\n";
   }
-  echo "<tr>\n"; 
-  echo "  <td colspan='".($n+2)."'><a href='".$formdata["processingfile"].(strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;")."new=add'>Add new item</a></td>\n"; 
-  echo "</tr>\n"; 
+  echo "<tr>\n";
+  echo "  <td colspan='".($n+2)."'><a href='".$formdata["processingfile"].(strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;")."new=add'>Add new item</a></td>\n";
+  echo "</tr>\n";
   if ($formdata["limit"]) {
-    echo "<tr>\n"; 
+    echo "<tr>\n";
     echo "  <td colspan='".($n+2)."'>";
-    
+
     $a = array();
     for($x=0;$x<$numrow/$formdata["limit"];$x++) {
       $a[] = sprintf("<a href='%s%s%s=%d'>%d</a>",
         $formdata["processingfile"],strstr($formdata["processingfile"],"?")===FALSE?"?":"&amp;",$formdata["startgetkey"],$x,$x+1);
     }
     echo implode(" | \n",$a);
-    echo "</td>\n"; 
-    echo "</tr>\n"; 
+    echo "</td>\n";
+    echo "</tr>\n";
   }
-  echo "</table>\n"; 
+  echo "</table>\n";
 }
 ?>

--- a/www_admin/common.inc.php
+++ b/www_admin/common.inc.php
@@ -1,13 +1,13 @@
-<?
+<?php
 class OpLock
 {
-  function __construct() 
+  function __construct()
   {
     $this->f = fopen(ADMIN_DIR . "/.oplock","wb");
     flock($this->f,LOCK_EX);
     fwrite($this->f,"open."); // this is to see if the lock gets stuck somewhere.
   }
-  function __destruct() 
+  function __destruct()
   {
     fwrite($this->f,"close.");
     flock($this->f,LOCK_UN);
@@ -51,7 +51,7 @@ function mb_wordwrap($str, $width=74, $break="\r\n")
 {
   if (!function_exists("mb_substr"))
     return wordwrap($str, $width, $break, 1);
-    
+
   // Return short or empty strings untouched
   if(empty($str) || mb_strlen($str, 'UTF-8') <= $width)
       return $str;
@@ -60,7 +60,7 @@ function mb_wordwrap($str, $width=74, $break="\r\n")
   $str_width = mb_strlen($str, 'UTF-8');
   $return = '';
   $last_space = false;
- 
+
   for($i=0, $count=0; $i < $str_width; $i++, $count++)
   {
       // If we're at a break
@@ -97,7 +97,7 @@ function mb_wordwrap($str, $width=74, $break="\r\n")
               {
                   $return = mb_substr($return, 0, -$drop);
               }
-             
+
               // Add a break
               $return .= $break;
 
@@ -132,14 +132,14 @@ function mb_wordwrap($str, $width=74, $break="\r\n")
 function handleUploadedRelease( $dataArray, &$output )
 {
   $lock = new OpLock();
-  
+
   global $settings;
-  
+
   $output = array();
-  
+
   $entry = null;
   $id = null;
-  if ($dataArray["id"]) 
+  if ($dataArray["id"])
   {
     // existing release
     $id = (int)$dataArray["id"];
@@ -169,18 +169,18 @@ function handleUploadedRelease( $dataArray, &$output )
       return false;
     }
   }
-  
+
   run_hook("admin_common_handleupload_beforecompocheck",array("dataArray"=>$dataArray,"output"=>&$output));
   if ($output["error"])
   {
     return false;
   }
-  
+
   $compo = null;
   if ($entry)
   {
     $compo = SQLLib::selectRow(sprintf_esc("select * from compos where id=%d",$entry->compoid));
-  } 
+  }
   else if ($dataArray["compoID"])
   {
     $compo = SQLLib::selectRow(sprintf_esc("select * from compos where id=%d",$dataArray["compoID"]));
@@ -214,11 +214,11 @@ function handleUploadedRelease( $dataArray, &$output )
     }
   }
 
-  // checks all done, start doing things  
+  // checks all done, start doing things
 
   $order = 0;
   if ($entry)
-  {  
+  {
     $order = $entry->playingorder;
   }
   else
@@ -229,12 +229,12 @@ function handleUploadedRelease( $dataArray, &$output )
 
   global $sqldata;
   $sqldata = array();
-  
+
   $meta = array("title","author","comment","orgacomment");
   foreach($meta as $v)
     if (isset($dataArray[$v]))
       $sqldata[$v] = $dataArray[$v];
-        
+
   // we already checked upload validity above - for admin interfaces, this check is disabled
   if ($dataArray["localFileName"] && file_exists($dataArray["localFileName"]))
   {
@@ -285,12 +285,12 @@ function handleUploadedRelease( $dataArray, &$output )
     $id = SQLLib::InsertRow("compoentries",$sqldata);
   }
   run_hook("admin_common_handleupload_afterdb",array("entryID"=>$id));
-    
+
   if (is_uploaded_file($dataArray["localScreenshotFile"])) {
     list($width,$height,$type) = getimagesize($dataArray["localScreenshotFile"]);
     if ($type==IMAGETYPE_GIF ||
         $type==IMAGETYPE_PNG ||
-        $type==IMAGETYPE_JPEG) 
+        $type==IMAGETYPE_JPEG)
     {
       @mkdir( get_screenshot_thumb_path() );
 
@@ -309,7 +309,7 @@ function handleUploadedRelease( $dataArray, &$output )
   }
 
   $output["entryID"] = $id;
-  return true;  
+  return true;
 }
 
 ///////////////////////////////////////////////////////////
@@ -329,7 +329,7 @@ function get_compo($id)
   global $_COMPOCACHE;
   if (!$_COMPOCACHE)
     _cache_compos();
-    
+
   //$compo = SQLLib::selectRow(sprintf_esc("select * from compos where id = %d",$_GET["id"]));
   return $_COMPOCACHE[$id];
 }
@@ -343,12 +343,12 @@ function is_user_logged_in() {
   return ($_SESSION["logindata"] && !!$_SESSION["logindata"]->id);
 }
 
-function get_user_id() 
+function get_user_id()
 {
   return (int)$_SESSION["logindata"]->id;
 }
 
-function get_current_user_data() 
+function get_current_user_data()
 {
   //return $_SESSION["logindata"];
   return SQLLib::selectRow(sprintf_esc("select * from users where id=%d",get_user_id()));
@@ -376,7 +376,7 @@ function get_compo_dir($compo)
   if(is_object($compo))
   {
     return $settings["private_ftp_dir"] . "/" . $compo->dirname . "/";
-  } 
+  }
   else
   {
     $obj = get_compo($compo);
@@ -390,7 +390,7 @@ function get_compo_dir_public($compo)
   if(is_object($compo))
   {
     return $settings["public_ftp_dir"] . "/" . $compo->dirname . "/";
-  } 
+  }
   else
   {
     $obj = get_compo($compo);
@@ -402,7 +402,7 @@ function get_compoentry_dir_path( $entry )
 {
   global $settings;
   global $_COMPOCACHE;
-  
+
   if (is_numeric($entry))
   {
     $entry = SQLLib::selectRow(sprintf_esc("select * from compoentries where id=%d",$entry));
@@ -424,7 +424,7 @@ function get_compoentry_file_path( $entry )
   }
   if (!is_object($entry))
     return null;
-    
+
   return get_compo_dir($entry->compoid) . sprintf("%03d",$entry->playingorder) . "/" . basename($entry->filename);
 }
 

--- a/www_admin/compos.php
+++ b/www_admin/compos.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("bootstrap.inc.php");
 
 if ($_GET['change']) {
@@ -32,13 +32,13 @@ $checkboxen = array(
 if ($_POST["delete"]) {
   SQLLib::Query(sprintf_esc("delete from compos where id=%d",$_POST["id"]));
   SQLLib::Query(sprintf_esc("delete from compoentries where compoid=%d",$_POST["id"]));
-  
+
   // TODO: delete directory, etc.
-  
+
 } else {
-  if ($_POST["name"] && $_POST["dirname"]) 
+  if ($_POST["name"] && $_POST["dirname"])
   {
-    if ($_POST["id"]) 
+    if ($_POST["id"])
     {
       $data = array(
         "name" => $_POST["name"],
@@ -49,7 +49,7 @@ if ($_POST["delete"]) {
         $data[$k] = $_POST[$k] == "on";
       run_hook("admin_compos_edit_update",array("data"=>&$data));
       SQLLib::UpdateRow("compos",$data,"id=".(int)$_POST["id"]);
-    } 
+    }
     else if ($_POST["addnewmulti"])
     {
       foreach($_POST["name"] as $k=>$v)
@@ -75,7 +75,7 @@ if ($_POST["delete"]) {
     }
   }
 }
-if ($_GET['id']) 
+if ($_GET['id'])
 {
   $compo = SQLLib::selectRow(sprintf_esc("select * from compos where id=%d",(int)$_GET['id']));
 ?>
@@ -87,7 +87,7 @@ if ($_GET['id'])
 </tr>
 <tr>
   <td>Compo start:</td>
-  <td><?
+  <td><?php
     list($startdate,$starttime) = explode(" ",$compo->start,2);
     printf("<select name='compostart_date'>");
     for ($x = 0; $x<10; $x++)
@@ -104,7 +104,7 @@ if ($_GET['id'])
   <td>Directory name:</td>
   <td><input id="dirname" name="dirname" type="text" value="<?=htmlspecialchars($compo->dirname)?>"/></td>
 </tr>
-<?
+<?php
 foreach($checkboxen as $k=>$v)
 {
 ?>
@@ -112,7 +112,7 @@ foreach($checkboxen as $k=>$v)
   <td><?=$v?></td>
   <td><input id="<?=$k?>" name="<?=$k?>" type="checkbox"<?=$compo->$k?' checked="checked"':""?>/></td>
 </tr>
-<?  
+<?php
 }
 run_hook("admin_compos_editform",array("compo"=>$compo));
 ?>
@@ -140,9 +140,9 @@ document.observe("dom:loaded",function(){
 });
 //-->
 </script>
-<?  
-} 
-else if ($_GET["new"]=="add") 
+<?php
+}
+else if ($_GET["new"]=="add")
 {
 ?>
 <form action="compos.php" method="post" id='addnewcompo'>
@@ -157,7 +157,7 @@ else if ($_GET["new"]=="add")
 <tbody>
 <tr class='comporow'>
   <td><input id="componame[0]" name="name[0]" class="componame" type="text"/></td>
-  <td><?
+  <td><?php
     printf("<select class='compostart_day' name='compostart_date[0]'>");
     for ($x = 0; $x<10; $x++)
     {
@@ -207,17 +207,17 @@ function instrument()
       tr.down(".dirname").value = tr.down(".componame").value.toLowerCase().replace(/[^a-zA-Z0-9]+/g,"_");
     });
   });
-    
+
 }
 document.observe("dom:loaded",function(){
   $("addnewcompo").select("td").each(function(item){
     original.push( item.innerHTML );
   });
-  instrument(); 
+  instrument();
 });
 //-->
 </script>
-<?
+<?php
 }
 else
 {
@@ -225,9 +225,9 @@ else
   ?>
   <table class='minuswiki' id='compolist'>
   <tr>
-<?
+<?php
   run_hook("admin_compolist_headerrow_start");
-?>  
+?>
     <th>Compo</th>
     <th>Edit</th>
     <th>Organize</th>
@@ -237,14 +237,14 @@ else
     <th>Voting</th>
     <th>Upload</th>
     <th>Editing</th>
-<?
+<?php
   run_hook("admin_compolist_headerrow_end");
-?>  
+?>
   </tr>
-  <?
+  <?php
   foreach($s as $t) {
     $z = SQLLib::selectRow(sprintf_esc("select count(*) as c from compoentries where compoid=%d",$t->id));
-    
+
     $class = "enoughentries";
     if ($z->c == 0) $class = "noentries";
     else if ($z->c < 3) $class = "fewentries";

--- a/www_admin/compos_entry_edit.php
+++ b/www_admin/compos_entry_edit.php
@@ -1,7 +1,7 @@
-<?
+<?php
 include_once("bootstrap.inc.php");
 
-  if ($_GET["select"]) 
+  if ($_GET["select"])
   {
     $lock = new OpLock();
     $e = SQLLib::selectRow(sprintf_esc("select * from compoentries where id=%d",$_GET["id"]));
@@ -15,12 +15,12 @@ include_once("bootstrap.inc.php");
   }
   include_once("header.inc.php");
 
-  if ($_POST["submit"]=="Move!") 
+  if ($_POST["submit"]=="Move!")
   {
     $lock = new OpLock();
     $e = SQLLib::selectRow(sprintf_esc("select * from compoentries where id=%d",$_POST["id"]));
     if (!$e) die("Error while getting compo entry");
-    
+
     $maxID = (int)SQLLib::selectRow(sprintf_esc("select max(playingorder) as c from compoentries where compoid=%d",$_POST["targetCompoID"]))->c + 1;
 
     $oldCompo = get_compo($e->compoid);
@@ -30,10 +30,10 @@ include_once("bootstrap.inc.php");
     $newDir = get_compo_dir($_POST["targetCompoID"]) . sprintf("%03d",$maxID) . "/";
     if (!$oldDir) die("Error while getting old compo entry dir");
     if (!$newDir) die("Error while getting new compo entry dir");
-    
+
     @mkdir( get_compo_dir($_POST["targetCompoID"]) );
     @chmod( get_compo_dir($_POST["targetCompoID"]) , 0777);
-    
+
     @mkdir($newDir);
     @chmod($newDir, 0777);
 
@@ -42,36 +42,36 @@ include_once("bootstrap.inc.php");
       $n = basename($v);
       rename($oldDir . $n, $newDir . $n);
     }
-    
+
     $a = array();
     $a["compoID"] = $_POST["targetCompoID"];
     $a["filename"] = basename($e->filename);
     $a["playingorder"] = $maxID;
     SQLLib::updateRow("compoentries",$a,"id=".(int)$_POST["id"]);
-    
+
     printf("<div class='success'>Entry %d moved to compo %s (%s)</div>\n",$_POST["id"],$newCompo->name,$newDir);
     $lock = null;
   }
-  
-  if ($_POST["submit"]=="Delete!") 
+
+  if ($_POST["submit"]=="Delete!")
   {
     $lock = new OpLock();
     $entry = SQLLib::selectRow(sprintf_esc("select * from compoentries where id=%d",$_POST["id"]));
     if (!$entry) die("Error while getting compo entry");
-    
+
     $dirname = get_compoentry_dir_path($entry);
     if (!$dirname) die("Error while getting compo entry dir");
-    
+
     $a = glob($dirname."*");
     foreach ($a as $v)
       unlink($v);
     rmdir($dirname);
-    
+
     SQLLib::Query(sprintf_esc("delete from compoentries where id=%d",$_POST["id"]));
     printf("<div class='success'>Entry %d deleted</div>\n",$_POST["id"]);
     $lock = null;
   }
-  
+
   $id = NULL;
   if ($_REQUEST["id"])
     $id = (int)$_REQUEST["id"];
@@ -97,28 +97,28 @@ include_once("bootstrap.inc.php");
   }
   if ($id)
     $entry = SQLLib::selectRow(sprintf_esc("select * from compoentries where id = %d",$id));
-    
+
 ?>
 <form action="compos_entry_edit.php?id=<?=$id?>" method="post" enctype="multipart/form-data">
 <table id="uploadform">
-<?
+<?php
 if ($id) {
 ?>
 <tr>
   <td>Compo:</td>
-  <td><?
+  <td><?php
   $s = get_compo($entry->compoid);
   printf("<a href='compos_entry_list.php?id=%d'>%s</a>",$s->id,$s->name);
   $dirname = get_compoentry_dir_path($entry);
   ?></td>
 </tr>
-<?
+<?php
 } else {
 ?>
 <tr>
   <td>Compo:</td>
   <td><select name="compo">
-<?
+<?php
 $dirname = NULL;
 $s = SQLLib::selectRows("select * from compos order by start");
 $compoID = NULL;
@@ -128,11 +128,11 @@ if ($_POST["compo"])
   $compoID = (int)$_POST["compo"];
 foreach($s as $t) {
   printf("  <option value='%d'%s>%s</option>\n",$t->id,$compoID==$t->id?" selected='selected'":"",$t->name);
-}  
-?>  
+}
+?>
   </select></td>
 </tr>
-<?
+<?php
 }
 ?>
 <tr>
@@ -151,10 +151,10 @@ foreach($s as $t) {
   <td>Comment for the organizers: (this will NOT be shown anywhere)</td>
   <td><textarea name="orgacomment"><?=_html($entry->orgacomment)?></textarea></td>
 </tr>
-<? if ($entry) { ?>
+<?php if ($entry) { ?>
 <tr>
   <td>Upload info:</td>
-  <td>Uploaded at <i><?=$entry->uploadtime?></i> from <i><?=$entry->uploadip?></i> by <?
+  <td>Uploaded at <i><?=$entry->uploadtime?></i> from <i><?=$entry->uploadip?></i> by <?php
     if ($entry->userid)
     {
       $user = SQLLib::SelectRow(sprintf_esc("select id,nickname from users where id = %d",$entry->userid));
@@ -162,24 +162,24 @@ foreach($s as $t) {
         printf("<a href='users.php?id=%d'>%s</a>\n",$user->id,_html($user->nickname));
     }
     else
-      echo "Admin superuser";      
+      echo "Admin superuser";
   ?></td>
 </tr>
-<? } ?>
+<?php } ?>
 <tr>
   <td>Uploaded files:</td>
   <td>
     <ul class='filelist'>
-    <?
+    <?php
     if ($dirname) {
       $a = glob($dirname."*");
-      
+
       foreach($a as $v)
       {
         $v = basename($v);
         if ($v == $entry->filename)
           printf("<li class='selectedfile'><span>%s</span> - %d bytes</li>\n",$v,filesize($dirname . $v));
-        else 
+        else
           printf("<li><span>%s</span> - %d bytes [<a href='compos_entry_edit.php?id=%d&amp;select=%s'>select</a>]</li>\n",
             $v,filesize($dirname . $v),$_GET["id"],_html($v));
       }
@@ -195,15 +195,15 @@ foreach($s as $t) {
 <tr>
   <td>Screenshot: (JPG, GIF or PNG!)</td>
   <td>
-<? if ($id) { ?>
+<?php if ($id) { ?>
   <div>
     <img src='screenshot.php?id=<?=(int)$id?>&amp;show=thumb' alt='thumb'/>
   </div>
-<? } ?>
+<?php } ?>
   <input name="screenshot" type="file" class="inputfield" accept="image/*" />
   </td>
 </tr>
-<?
+<?php
 run_hook("admin_editentry_editform",array("entry"=>$entry));
 ?>
 <tr>
@@ -227,26 +227,26 @@ document.observe("dom:loaded",function(){
 </script>
 
 
-<? if ($id) { ?>
+<?php if ($id) { ?>
 <form action="compos_entry_edit.php?id=<?=$id?>" method="post" enctype="multipart/form-data">
   <h2>Move to compo:</h2>
   <input type="hidden" value="<?=$id?>" name="id"/>
   <select name="targetCompoID">
-<?
+<?php
 $dirname = NULL;
 $s = SQLLib::selectRows("select * from compos order by start");
 foreach($s as $t) {
   if ($t->id == $entry->compoid) continue;
   printf("  <option value='%d'%s>%s</option>\n",$t->id,max($entry->compoid,$_GET["compo"])==$t->id?" selected='selected'":"",$t->name);
-}  
-?>  
+}
+?>
   </select>
   <div>
     <input type="submit" name="submit" value="Move!" />
   </div>
 </form>
-<? } ?>
+<?php } ?>
 
-<?
+<?php
   include_once("footer.inc.php");
 ?>

--- a/www_admin/compos_entry_list.php
+++ b/www_admin/compos_entry_list.php
@@ -1,38 +1,38 @@
-<?
+<?php
 include_once("bootstrap.inc.php");
 
 loadPlugins();
 
 $compo = get_compo( $_GET["id"] );
 
-function changeShowingNumber($entryID, $from, $to) 
+function changeShowingNumber($entryID, $from, $to)
 {
   error_reporting(E_ALL ^ E_NOTICE);
   global $settings,$compo;
   $s = SQLLib::selectRow(sprintf_esc("select * from compoentries where playingorder = %d and compoid = %d",$from,$entryID));
   if (!$s) return;
-  
-  $root = get_compo_dir($compo);  
-  
+
+  $root = get_compo_dir($compo);
+
   $olddir = $root . sprintf("%03d",$from);
   $newdir = $root . sprintf("%03d",$to);
-  
+
   rename($olddir,$newdir);
-  
+
   SQLLib::Query(sprintf_esc("update compoentries set playingorder=%d where id=%d",$to,$s->id));
 }
 
-if ($_GET['direction']) 
+if ($_GET['direction'])
 {
   $lock = new OpLock();
   $s = SQLLib::selectRow(sprintf_esc("select * from compoentries where id = %d",$_GET["pid"]));
 
   $delta = $_GET['direction']=="up" ? -1 : 1;
-  
+
   changeShowingNumber( $_GET["id"], $s->playingorder+$delta, -1 );
   changeShowingNumber( $_GET["id"], $s->playingorder, $s->playingorder+$delta );
   changeShowingNumber( $_GET["id"], -1, $s->playingorder );
-  
+
   header("Location: compos_entry_list.php?id=".$_GET["id"]);
   exit();
 }
@@ -45,7 +45,7 @@ printf("<h2>%s</h2>\n",$compo->name);
 if ($_POST["submit"] == "Export!")
 {
   $lock = new OpLock(); // is this needed? probably not but it can't hurt
-  
+
   @mkdir( get_compo_dir_public( $compo ) );
   @chmod( get_compo_dir_public( $compo ), 0777 );
 
@@ -90,20 +90,20 @@ run_hook("admin_compo_entrylist_start");
   <th>Uploader</th>
   <th>File name</th>
   <th>File size</th>
-<?
+<?php
   $compo = get_compo( $_GET["id"] );
   if ($compo->votingopen == 0)
     echo "<th colspan='2'>Re-order</th>\n";
 ?>
   <th>Upload time</th>
-<?
+<?php
   run_hook("admin_compo_entrylist_headerrow_end");
 ?>
 </tr>
-<?
+<?php
 $n = 1;
 global $entry;
-foreach($entries as $entry) 
+foreach($entries as $entry)
 {
   printf("<tr class='entry'>\n");
   printf("  <td%s>%d.</td>\n",$entry->playingorder!=$n?" style='color:red; font-weight:bold;'":"",$entry->playingorder);
@@ -116,13 +116,13 @@ foreach($entries as $entry)
     printf("  <td>Admin superuser</td>\n");
   printf("  <td>%s</td>\n",basename($entry->filename));
   @printf("  <td>%d bytes</td>\n",filesize(get_compoentry_file_path($entry)));
-  if ($compo->votingopen == 0) 
+  if ($compo->votingopen == 0)
   {
-    if ($entry->playingorder > 1) 
+    if ($entry->playingorder > 1)
       printf("  <td class='move moveup'><a href='compos_entry_list.php?pid=%d&amp;id=%d&amp;direction=up'>&uarr;</a></td>\n",$entry->id,$_GET["id"]);
     else
       printf("  <td class='move moveup'>&nbsp;</td>\n");
-    if ($n < count($entries)) 
+    if ($n < count($entries))
       printf("  <td class='move movedown'><a href='compos_entry_list.php?pid=%d&amp;id=%d&amp;direction=down'>&darr;</a></td>\n",$entry->id,$_GET["id"]);
     else
       printf("  <td class='move movedown'>&nbsp;</td>\n");
@@ -145,6 +145,6 @@ run_hook("admin_compo_entrylist_end");
   </div>
   <small>(Note: whether this is publicly visible or not depends on how you set your server up! The directory is <b><?=_html($settings["public_ftp_dir"])?></b>)</small>
 </form>
-<?
+<?php
 include_once("footer.inc.php");
 ?>

--- a/www_admin/config.php
+++ b/www_admin/config.php
@@ -1,5 +1,5 @@
 <?php
-if (version_compare(PHP_VERSION, '5.5.0', '<')) 
+if (version_compare(PHP_VERSION, '5.5.0', '<'))
 {
   die("Please use a more recent version of PHP - at least 5.5!");
   exit();
@@ -17,7 +17,7 @@ include_once("sqllib.inc.php");
 <head>
  <title>party management system whatever thing config</title>
  <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2" />
- 
+
 <style type="text/css">
 body {
   background: black;
@@ -82,20 +82,20 @@ a {
   color: #400;
 }
 
-</style> 
+</style>
 </head>
 <body>
 
-<?
+<?php
 $_POST = clearArray($_POST);
 function perform(&$msg) {
   $msg = "";
-  
+
   if (!function_exists("mysqli_connect")) {
     $msg = "Unable to load MySQLi extension!";
     return 0;
   }
-  
+
   if (!function_exists("imagecopyresampled")) {
     $msg = "Unable to load GD2 extension!";
     return 0;
@@ -112,22 +112,22 @@ function perform(&$msg) {
     $msg = "Unable to write into admin directory!";
     return 0;
   }
-    
+
   if (!is_writable($_POST["main_www_dir"]."/")) {
     $msg = "Unable to write into user-side interface directory!";
     return 0;
   }
-  
+
   if (file_put_contents($_POST["main_www_dir"]."/database.inc.php","test")===FALSE) {
     $msg = "Unable to create file into user-side interface directory!";
     return 0;
   }
-  
+
   if (!is_writable($_POST["private_ftp_dir"]."/")) {
     $msg = "Unable to write into compo entry directory!";
     return 0;
   }
-  
+
   if ($_POST["public_ftp_dir"] && !is_writable($_POST["public_ftp_dir"]."/")) {
     $msg = "Unable to write into compo export directory!";
     return 0;
@@ -139,14 +139,14 @@ function perform(&$msg) {
   }
 
   // end of checks
-    
+
   SQLLib::$link = mysqli_connect("localhost",$_POST["mysql_username"],$_POST["mysql_password"],$_POST["mysql_database"]);
   if (mysqli_connect_errno(SQLLib::$link))
   {
     $msg = "Unable to connect to MySQL: ".mysqli_connect_error();
     return 0;
   }
-  
+
   $charsets = array("utf8mb4","utf8");
   SQLLib::$charset = "";
   foreach($charsets as $c)
@@ -178,7 +178,7 @@ function perform(&$msg) {
         SQLLib::Query($c);
       }
     }
-    
+
     $queries = array(
       sprintf_esc("insert into settings (setting,value) values ('private_ftp_dir' ,'%s')",$_POST["private_ftp_dir"]),
       sprintf_esc("insert into settings (setting,value) values ('public_ftp_dir'  ,'%s')",$_POST["public_ftp_dir"]),
@@ -200,7 +200,7 @@ function perform(&$msg) {
 
   $salt = "";
   for($x=0;$x<64;$x++) $salt.=chr(rand(0x30,0x7a));
-  $db =   
+  $db =
   "<"."?\n".
   "define('SQL_HOST','localhost');\n".
   "define('SQL_USERNAME',\"".addslashes($_POST["mysql_username"])."\");\n".
@@ -210,10 +210,10 @@ function perform(&$msg) {
   "define('ADMIN_DIR',\"".dirname($_SERVER["SCRIPT_FILENAME"])."\");\n".
   "define('PASSWORD_SALT',\"".addslashes($salt)."\");\n".
   "?".">\n";
-  
+
   file_put_contents("database.inc.php",$db);
   file_put_contents($_POST["main_www_dir"]."/database.inc.php",$db);
-  
+
   if ($_POST["admin_username"] && $_POST["admin_password"] ) {
     $htaccess =
     "AuthUserFile ".dirname($_SERVER["SCRIPT_FILENAME"])."/.htpasswd\n".
@@ -222,11 +222,11 @@ function perform(&$msg) {
     "AuthType Basic\n".
     "\n".
     "require valid-user\n";
-  
+
     file_put_contents(".htaccess",$htaccess);
-    
+
     $htpasswd = $_POST["admin_username"] . ":" . crypt( $_POST["admin_password"] );
-  
+
     file_put_contents(".htpasswd",$htpasswd);
   }
 
@@ -241,7 +241,7 @@ function perform(&$msg) {
   }
   //@mkdir($_POST["screenshot_dir"] . "/thumb/");
   //@chmod($_POST["screenshot_dir"] . "/thumb/",0777);
-  
+
   $msg = "Everything went fine!";
   return 1;
 }
@@ -335,7 +335,7 @@ Hi. Welcome. Good luck.
   <small>(This will be used for both width and height.)</small>
   </td>
   <td>
-  <input name="screenshot_sizex" class="resolution" value="<?=htmlspecialchars($_POST["screenshot_sizex"]?$_POST["screenshot_sizex"]:"160")?>"/> x 
+  <input name="screenshot_sizex" class="resolution" value="<?=htmlspecialchars($_POST["screenshot_sizex"]?$_POST["screenshot_sizex"]:"160")?>"/> x
   <input name="screenshot_sizey" class="resolution" value="<?=htmlspecialchars($_POST["screenshot_sizey"]?$_POST["screenshot_sizey"]:"90")?>"/>
   </td>
 </tr>
@@ -358,10 +358,10 @@ Hi. Welcome. Good luck.
 
 <tr>
   <td>MySQL database name for the party engine:
-<?
+<?php
 $a = glob("plugins/adminer/adminer-*.php");
 if ($a) printf("<small>Haven't set one up yet? <a href='%s' target='_blank'>Here's a web interface to help!</a></small>",$a[0]);
-?>  
+?>
   </td>
   <td>
   <input name="mysql_database" value="<?=htmlspecialchars($_POST["mysql_database"]?$_POST["mysql_database"]:"")?>"/>

--- a/www_admin/config.php
+++ b/www_admin/config.php
@@ -220,7 +220,7 @@ function perform(&$msg) {
 
     file_put_contents(".htaccess",$htaccess);
 
-    $htpasswd = $_POST["admin_username"] . ":" . crypt( $_POST["admin_password"] );
+    $htpasswd = $_POST["admin_username"] . ":" . password_hash($_POST["admin_password"], PASSWORD_DEFAULT);
 
     file_put_contents(".htpasswd",$htpasswd);
   }

--- a/www_admin/config.php
+++ b/www_admin/config.php
@@ -4,11 +4,6 @@ if (version_compare(PHP_VERSION, '5.5.0', '<'))
   die("Please use a more recent version of PHP - at least 5.5!");
   exit();
 }
-if (!ini_get("short_open_tag"))
-{
-  die("Please enable the 'short_open_tag' in php.ini to use Wuhu");
-  exit();
-}
 define("SQLLIB_SUPPRESSCONNECT",true);
 include_once("sqllib.inc.php");
 ?>

--- a/www_admin/config.php
+++ b/www_admin/config.php
@@ -196,7 +196,7 @@ function perform(&$msg) {
   $salt = "";
   for($x=0;$x<64;$x++) $salt.=chr(rand(0x30,0x7a));
   $db =
-  "<"."?\n".
+  "<"."?php\n".
   "define('SQL_HOST','localhost');\n".
   "define('SQL_USERNAME',\"".addslashes($_POST["mysql_username"])."\");\n".
   "define('SQL_PASSWORD',\"".addslashes($_POST["mysql_password"])."\");\n".

--- a/www_admin/config.php
+++ b/www_admin/config.php
@@ -241,7 +241,7 @@ function perform(&$msg) {
   return 1;
 }
 
-if ($_POST["main_www_dir"]) {
+if (isset($_POST["main_www_dir"])) {
   $b = perform($msg);
   if ($b) {
     echo "<div class='success'>".htmlspecialchars($msg)." <a href='./'>Click here to start!</a> </div>";
@@ -288,7 +288,7 @@ Hi. Welcome. Good luck.
   <small>(This should have read/write permissions for PHP (<?=get_current_user()?>).)</small>
   </td>
   <td>
-  <input name="main_www_dir" value="<?=htmlspecialchars($_POST["main_www_dir"]?$_POST["main_www_dir"]:"/var/www/www_party")?>"/>
+  <input name="main_www_dir" value="<?=htmlspecialchars(isset($_POST["main_www_dir"])?$_POST["main_www_dir"]:"/var/www/www_party")?>"/>
   </td>
 </tr>
 
@@ -298,7 +298,7 @@ Hi. Welcome. Good luck.
   <small>(This should be an organizer-only dir, possibly FTP accessible, with read/write permissions for Apache.)</small>
   </td>
   <td>
-  <input name="private_ftp_dir" value="<?=htmlspecialchars($_POST["private_ftp_dir"]?$_POST["private_ftp_dir"]:"/var/www/entries_private")?>"/>
+  <input name="private_ftp_dir" value="<?=htmlspecialchars(isset($_POST["private_ftp_dir"])?$_POST["private_ftp_dir"]:"/var/www/entries_private")?>"/>
   </td>
 </tr>
 
@@ -310,7 +310,7 @@ Hi. Welcome. Good luck.
   share the files with the visitors or to upload to scene.org. Should have read/write permissions for Apache.)</small>
   </td>
   <td>
-  <input name="public_ftp_dir" value="<?=htmlspecialchars($_POST["public_ftp_dir"]?$_POST["public_ftp_dir"]:"")?>"/>
+  <input name="public_ftp_dir" value="<?=htmlspecialchars(isset($_POST["public_ftp_dir"])?$_POST["public_ftp_dir"]:"")?>"/>
   </td>
 </tr>
 
@@ -321,7 +321,7 @@ Hi. Welcome. Good luck.
   but it doesn't have to be accessible for anyone else.)</small>
   </td>
   <td>
-  <input name="screenshot_dir" value="<?=htmlspecialchars($_POST["screenshot_dir"]?$_POST["screenshot_dir"]:"/var/www/screenshots")?>"/>
+  <input name="screenshot_dir" value="<?=htmlspecialchars(isset($_POST["screenshot_dir"])?$_POST["screenshot_dir"]:"/var/www/screenshots")?>"/>
   </td>
 </tr>
 
@@ -330,8 +330,8 @@ Hi. Welcome. Good luck.
   <small>(This will be used for both width and height.)</small>
   </td>
   <td>
-  <input name="screenshot_sizex" class="resolution" value="<?=htmlspecialchars($_POST["screenshot_sizex"]?$_POST["screenshot_sizex"]:"160")?>"/> x
-  <input name="screenshot_sizey" class="resolution" value="<?=htmlspecialchars($_POST["screenshot_sizey"]?$_POST["screenshot_sizey"]:"90")?>"/>
+  <input name="screenshot_sizex" class="resolution" value="<?=htmlspecialchars(isset($_POST["screenshot_sizex"])?$_POST["screenshot_sizex"]:"160")?>"/> x
+  <input name="screenshot_sizey" class="resolution" value="<?=htmlspecialchars(isset($_POST["screenshot_sizey"])?$_POST["screenshot_sizey"]:"90")?>"/>
   </td>
 </tr>
 
@@ -346,7 +346,7 @@ Hi. Welcome. Good luck.
 <tr>
   <td>Party starting day:</td>
   <td>
-  <input name="party_firstday" value="<?=htmlspecialchars($_POST["party_firstday"]?$_POST["party_firstday"]:date("Y-m-d"))?>"/>
+  <input name="party_firstday" value="<?=htmlspecialchars(isset($_POST["party_firstday"])?$_POST["party_firstday"]:date("Y-m-d"))?>"/>
   </td>
 </tr>
 
@@ -359,35 +359,35 @@ if ($a) printf("<small>Haven't set one up yet? <a href='%s' target='_blank'>Here
 ?>
   </td>
   <td>
-  <input name="mysql_database" value="<?=htmlspecialchars($_POST["mysql_database"]?$_POST["mysql_database"]:"")?>"/>
+  <input name="mysql_database" value="<?=htmlspecialchars(isset($_POST["mysql_database"])?$_POST["mysql_database"]:"")?>"/>
   </td>
 </tr>
 
 <tr>
   <td>MySQL username for the party engine:</td>
   <td>
-  <input name="mysql_username" value="<?=htmlspecialchars($_POST["mysql_username"]?$_POST["mysql_username"]:"")?>"/>
+  <input name="mysql_username" value="<?=htmlspecialchars(isset($_POST["mysql_username"])?$_POST["mysql_username"]:"")?>"/>
   </td>
 </tr>
 
 <tr>
   <td>MySQL password for the party engine:</td>
   <td>
-  <input name="mysql_password" value="<?=htmlspecialchars($_POST["mysql_password"]?$_POST["mysql_password"]:"")?>" type="password"/>
+  <input name="mysql_password" value="<?=htmlspecialchars(isset($_POST["mysql_password"])?$_POST["mysql_password"]:"")?>" type="password"/>
   </td>
 </tr>
 
 <tr>
   <td>Party admin interface username:</td>
   <td>
-  <input name="admin_username" value="<?=htmlspecialchars($_POST["admin_username"]?$_POST["admin_username"]:"")?>"/>
+  <input name="admin_username" value="<?=htmlspecialchars(isset($_POST["admin_username"])?$_POST["admin_username"]:"")?>"/>
   </td>
 </tr>
 
 <tr>
   <td>Party admin interface password:</td>
   <td>
-  <input name="admin_password" value="<?=htmlspecialchars($_POST["admin_password"]?$_POST["admin_password"]:"")?>" type="password"/>
+  <input name="admin_password" value="<?=htmlspecialchars(isset($_POST["admin_password"])?$_POST["admin_password"]:"")?>" type="password"/>
   </td>
 </tr>
 

--- a/www_admin/config.php
+++ b/www_admin/config.php
@@ -241,7 +241,7 @@ function perform(&$msg) {
   return 1;
 }
 
-if (isset($_POST["main_www_dir"])) {
+if (empty($_POST["main_www_dir"])) {
   $b = perform($msg);
   if ($b) {
     echo "<div class='success'>".htmlspecialchars($msg)." <a href='./'>Click here to start!</a> </div>";
@@ -288,7 +288,7 @@ Hi. Welcome. Good luck.
   <small>(This should have read/write permissions for PHP (<?=get_current_user()?>).)</small>
   </td>
   <td>
-  <input name="main_www_dir" value="<?=htmlspecialchars(isset($_POST["main_www_dir"])?$_POST["main_www_dir"]:"/var/www/www_party")?>"/>
+  <input name="main_www_dir" value="<?=htmlspecialchars(empty($_POST["main_www_dir"])?$_POST["main_www_dir"]:"/var/www/www_party")?>"/>
   </td>
 </tr>
 
@@ -298,7 +298,7 @@ Hi. Welcome. Good luck.
   <small>(This should be an organizer-only dir, possibly FTP accessible, with read/write permissions for Apache.)</small>
   </td>
   <td>
-  <input name="private_ftp_dir" value="<?=htmlspecialchars(isset($_POST["private_ftp_dir"])?$_POST["private_ftp_dir"]:"/var/www/entries_private")?>"/>
+  <input name="private_ftp_dir" value="<?=htmlspecialchars(empty($_POST["private_ftp_dir"])?$_POST["private_ftp_dir"]:"/var/www/entries_private")?>"/>
   </td>
 </tr>
 
@@ -310,7 +310,7 @@ Hi. Welcome. Good luck.
   share the files with the visitors or to upload to scene.org. Should have read/write permissions for Apache.)</small>
   </td>
   <td>
-  <input name="public_ftp_dir" value="<?=htmlspecialchars(isset($_POST["public_ftp_dir"])?$_POST["public_ftp_dir"]:"")?>"/>
+  <input name="public_ftp_dir" value="<?=htmlspecialchars(empty($_POST["public_ftp_dir"])?$_POST["public_ftp_dir"]:"")?>"/>
   </td>
 </tr>
 
@@ -321,7 +321,7 @@ Hi. Welcome. Good luck.
   but it doesn't have to be accessible for anyone else.)</small>
   </td>
   <td>
-  <input name="screenshot_dir" value="<?=htmlspecialchars(isset($_POST["screenshot_dir"])?$_POST["screenshot_dir"]:"/var/www/screenshots")?>"/>
+  <input name="screenshot_dir" value="<?=htmlspecialchars(empty($_POST["screenshot_dir"])?$_POST["screenshot_dir"]:"/var/www/screenshots")?>"/>
   </td>
 </tr>
 
@@ -330,8 +330,8 @@ Hi. Welcome. Good luck.
   <small>(This will be used for both width and height.)</small>
   </td>
   <td>
-  <input name="screenshot_sizex" class="resolution" value="<?=htmlspecialchars(isset($_POST["screenshot_sizex"])?$_POST["screenshot_sizex"]:"160")?>"/> x
-  <input name="screenshot_sizey" class="resolution" value="<?=htmlspecialchars(isset($_POST["screenshot_sizey"])?$_POST["screenshot_sizey"]:"90")?>"/>
+  <input name="screenshot_sizex" class="resolution" value="<?=htmlspecialchars(empty($_POST["screenshot_sizex"])?$_POST["screenshot_sizex"]:"160")?>"/> x
+  <input name="screenshot_sizey" class="resolution" value="<?=htmlspecialchars(empty($_POST["screenshot_sizey"])?$_POST["screenshot_sizey"]:"90")?>"/>
   </td>
 </tr>
 
@@ -346,7 +346,7 @@ Hi. Welcome. Good luck.
 <tr>
   <td>Party starting day:</td>
   <td>
-  <input name="party_firstday" value="<?=htmlspecialchars(isset($_POST["party_firstday"])?$_POST["party_firstday"]:date("Y-m-d"))?>"/>
+  <input name="party_firstday" value="<?=htmlspecialchars(empty($_POST["party_firstday"])?$_POST["party_firstday"]:date("Y-m-d"))?>"/>
   </td>
 </tr>
 
@@ -359,35 +359,35 @@ if ($a) printf("<small>Haven't set one up yet? <a href='%s' target='_blank'>Here
 ?>
   </td>
   <td>
-  <input name="mysql_database" value="<?=htmlspecialchars(isset($_POST["mysql_database"])?$_POST["mysql_database"]:"")?>"/>
+  <input name="mysql_database" value="<?=htmlspecialchars(empty($_POST["mysql_database"])?$_POST["mysql_database"]:"")?>"/>
   </td>
 </tr>
 
 <tr>
   <td>MySQL username for the party engine:</td>
   <td>
-  <input name="mysql_username" value="<?=htmlspecialchars(isset($_POST["mysql_username"])?$_POST["mysql_username"]:"")?>"/>
+  <input name="mysql_username" value="<?=htmlspecialchars(empty($_POST["mysql_username"])?$_POST["mysql_username"]:"")?>"/>
   </td>
 </tr>
 
 <tr>
   <td>MySQL password for the party engine:</td>
   <td>
-  <input name="mysql_password" value="<?=htmlspecialchars(isset($_POST["mysql_password"])?$_POST["mysql_password"]:"")?>" type="password"/>
+  <input name="mysql_password" value="<?=htmlspecialchars(empty($_POST["mysql_password"])?$_POST["mysql_password"]:"")?>" type="password"/>
   </td>
 </tr>
 
 <tr>
   <td>Party admin interface username:</td>
   <td>
-  <input name="admin_username" value="<?=htmlspecialchars(isset($_POST["admin_username"])?$_POST["admin_username"]:"")?>"/>
+  <input name="admin_username" value="<?=htmlspecialchars(empty($_POST["admin_username"])?$_POST["admin_username"]:"")?>"/>
   </td>
 </tr>
 
 <tr>
   <td>Party admin interface password:</td>
   <td>
-  <input name="admin_password" value="<?=htmlspecialchars(isset($_POST["admin_password"])?$_POST["admin_password"]:"")?>" type="password"/>
+  <input name="admin_password" value="<?=htmlspecialchars(empty($_POST["admin_password"])?$_POST["admin_password"]:"")?>" type="password"/>
   </td>
 </tr>
 

--- a/www_admin/cron.php
+++ b/www_admin/cron.php
@@ -1,4 +1,4 @@
-<?
+<?php
 define("ADMIN_PAGE",true);
 include_once( dirname(__FILE__) . "/bootstrap.inc.php" );
 

--- a/www_admin/csrf.inc.php
+++ b/www_admin/csrf.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class CSRFProtect
 {
   public function __construct()

--- a/www_admin/footer.inc.php
+++ b/www_admin/footer.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 run_hook("admin_content_end");
 ?>
   <!-- end content -->
@@ -6,12 +6,12 @@ run_hook("admin_content_end");
       <small>2007-<?=date("Y")?> &copy; <a href="http://wuhu.function.hu">wuhu</a>
       by Function organizing</small>
     </div>
-  
+
   </div>
 
 </div>
 </body>
 </html>
-<?
+<?php
 run_hook("admin_page_end");
 ?>

--- a/www_admin/header.inc.php
+++ b/www_admin/header.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 define("ADMIN_PAGE",true);
 include_once("bootstrap.inc.php");
 
@@ -10,10 +10,10 @@ run_hook("admin_page_start");
 <head>
   <title>wuhu - <?=basename($_SERVER["PHP_SELF"])?></title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <link rel="stylesheet" type="text/css" href="style.css"/> 
+  <link rel="stylesheet" type="text/css" href="style.css"/>
   <script type="text/javascript" src="prototype.js"></script>
   <meta name="viewport" content="width=device-width; initial-scale=1.0;" />
-<?
+<?php
 run_hook("admin_head");
 ?>
 </head>
@@ -47,7 +47,7 @@ run_hook("admin_head");
       <li><a href="results.php">Results</a> </li>
       <li><hr/></li>
       <li>Plugins (<a href='plugins.php'>edit</a>):</li>
-<?
+<?php
 $pluginlinks = array();
 run_hook("admin_menu",array("links"=>&$pluginlinks));
 if ($pluginlinks)
@@ -59,13 +59,13 @@ else
 {
     printf("      <li>none</li>\n");
 }
-?>      
+?>
     </ul>
 
   </div>
 
   <div id="content">
   <!-- start content -->
-<?
+<?php
 run_hook("admin_content_start");
 ?>

--- a/www_admin/hooks.inc.php
+++ b/www_admin/hooks.inc.php
@@ -66,7 +66,7 @@ function get_cron_log( $cronName )
   return SQLLib::SelectRow(sprintf_esc("select * from cron where cronname='%s'",$cronName));
 }
 
-define( PLUGINREGISTRY, ADMIN_DIR . "/activeplugins.serialize" );
+define("PLUGINREGISTRY", ADMIN_DIR . "/activeplugins.serialize");
 
 function get_plugin_entry_path( $name )
 {

--- a/www_admin/hooks.inc.php
+++ b/www_admin/hooks.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 // todo: priority levels and/or possibility to cancel future actions?
 
 $HOOKS = array();
@@ -13,7 +13,7 @@ function run_hook( $hookpoint, $args = null )
   global $HOOKS;
 
   if (!$HOOKS[$hookpoint]) return;
-  
+
   foreach($HOOKS[$hookpoint] as $v) $v($args);
 }
 
@@ -21,7 +21,7 @@ function add_activation_hook( $pluginPath, $func )
 {
   if (preg_match("/plugins\/([a-zA-Z_\-0-9]+)[\/.]/",$pluginPath,$m))
     $pluginPath = $m[1];
-  
+
   return add_hook( $pluginPath . "_activation", $func );
 }
 
@@ -76,21 +76,21 @@ function get_plugin_entry_path( $name )
     ADMIN_DIR . "/plugins/" . $name . ".php",
   );
   foreach ($entryfiles as $file)
-    if (file_exists($file)) 
+    if (file_exists($file))
       return $file;
   return NULL;
 }
 
 function loadPlugins()
-{  
+{
   $data = @file_get_contents(PLUGINREGISTRY);
   $activePlugins = unserialize($data);
   if (!$activePlugins) $activePlugins = array();
-  
+
   foreach($activePlugins as $dirname=>$data)
   {
     $path = get_plugin_entry_path( $dirname );
-    if ($path && file_exists($path)) 
+    if ($path && file_exists($path))
     {
       include_once($path);
     }

--- a/www_admin/index.php
+++ b/www_admin/index.php
@@ -51,9 +51,9 @@ printf("<ol id='maintodolist'>\n");
 foreach($checks as $func=>$description)
 {
   if ($func())
-    printf("<li><s>%s</s></li>\n",$description);  
+    printf("<li><s>%s</s></li>\n",$description);
   else
-    printf("<li>%s</li>\n",$description);  
+    printf("<li>%s</li>\n",$description);
 }
 printf("</ol>\n");
 

--- a/www_admin/news.php
+++ b/www_admin/news.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("header.inc.php");
 
 $formdata = array(
@@ -33,14 +33,14 @@ $formdata = array(
       "format"=>"text",
       "grid"=>true,
     ),
-/*    
+/*
     "hun_body"=>array(
       "sqlfield"=>"hun_body",
       "caption"=>"Body (Hungarian)",
       "format"=>"textarea",
       "grid"=>false,
     ),
-*/    
+*/
     "eng_body"=>array(
       "sqlfield"=>"eng_body",
       "caption"=>"Body (English)",

--- a/www_admin/pages.php
+++ b/www_admin/pages.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("header.inc.php");
 
 $formdata = array(

--- a/www_admin/pluginoptions.php
+++ b/www_admin/pluginoptions.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("header.inc.php");
 
 define("PLUGINOPTIONS",true);

--- a/www_admin/plugins.php
+++ b/www_admin/plugins.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("bootstrap.inc.php");
 
 $data = @file_get_contents(PLUGINREGISTRY);
@@ -17,7 +17,7 @@ if ($_POST["submit"])
     $activePlugins[$dirname] = array();
     $activePlugins[$dirname]["active"] = true;
     $activePlugins[$dirname]["directory"] = $dirname;
-    
+
     //$entryfile = ADMIN_DIR . "/plugins/" . $dirname . "/plugin.php";
     $path = get_plugin_entry_path( $dirname );
     if ($path && file_exists($path))
@@ -46,7 +46,7 @@ printf("<ul id='pluginlist'>\n");
 $files = array();
 $files = array_merge( $files, glob(ADMIN_DIR . "/plugins/*.php") );
 $files = array_merge( $files, glob(ADMIN_DIR . "/plugins/*/", GLOB_ONLYDIR) );
-usort($files,"strcasecmp");                                   
+usort($files,"strcasecmp");
 foreach($files as $v)
 {
   if (!preg_match("/\/plugins\/(.*)[\/\.]/",$v,$m))
@@ -59,16 +59,16 @@ foreach($files as $v)
     $pluginDirName = $name;
     $pluginName = $name;
     $pluginDescription = "";
-    
+
     $f = fopen($path,"rt");
     $data = fread($f,1024);
     fclose($f);
-    
+
     if(preg_match("/^Plugin name: (.*)$/im",$data,$m))
       $pluginName = $m[1];
     if(preg_match("/^Description: (.*)$/im",$data,$m))
       $pluginDescription = $m[1];
-        
+
     printf("<li>\n");
     printf("  <h3>%s</h3>\n",htmlspecialchars($pluginName));
     printf("  <input type='checkbox' name='plugin[%s]'%s>\n",htmlspecialchars($pluginDirName),$activePlugins[$pluginDirName] ? " checked='checked'" : "");

--- a/www_admin/plugins/adminer/adminer.php
+++ b/www_admin/plugins/adminer/adminer.php
@@ -1,7 +1,7 @@
-<?
+<?php
 include_once("../../database.inc.php");
 
-function adminer_object() 
+function adminer_object()
 {
   class AdminerSoftware extends Adminer {
     function name() { return "Wuhu Adminer Plugin"; }

--- a/www_admin/plugins/adminer/plugin.php
+++ b/www_admin/plugins/adminer/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Adminer for Wuhu
 Description: Adminer (formerly phpMinAdmin) is a full-featured database management tool written in PHP. Conversely to phpMyAdmin, it consist of a single file ready to deploy to the target server. Adminer is available for MySQL, PostgreSQL, SQLite, MS SQL and Oracle.

--- a/www_admin/plugins/beamer_resultlimit.php
+++ b/www_admin/plugins/beamer_resultlimit.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Result limit
 Description: Limits the number of entries shown for each compo on the beamer
@@ -19,7 +19,7 @@ function resultlimit_editform( $data )
   <td>Number of top entries to show during prizegiving: <small>(0 = all of them)</small></td>
   <td><input id="resultlimit" name="resultlimit" type="text" value="<?=htmlspecialchars($data["compo"]->resultlimit)?>"/></td>
 </tr>
-<?
+<?php
 }
 add_hook("admin_compos_editform","resultlimit_editform");
 

--- a/www_admin/plugins/compobreakdown/options.php
+++ b/www_admin/plugins/compobreakdown/options.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR") || !defined("PLUGINOPTIONS"))
   exit();
 
@@ -16,7 +16,7 @@ $dir = get_compo_dir($compo);
 
 printf("  <dl id='breakdown'>\n");
 $playingorder = 1;
-foreach ($entries as $t) 
+foreach ($entries as $t)
 {
   $path = substr(get_compoentry_file_path($t),strlen($dir));
   printf("      <dt>#%d. <a href='compos_entry_edit.php?id=%d'>%s</a> - %s <span class='filename'>(%s)</span></dt>\n",$playingorder++,$t->id,_html($t->title),_html($t->author),$path);

--- a/www_admin/plugins/compobreakdown/plugin.php
+++ b/www_admin/plugins/compobreakdown/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Compo breakdown
 Description: Allows the organizer to add notes to self to entries, and view the compo as a "breakdown list" (which files are the correct ones, what the notes are)
@@ -23,7 +23,7 @@ function compobreakdown_editform( $data )
     "which platform", "which emulator", "this one is long", "leave running after fadeout", etc.)</small></td>
   <td><textarea id="organotes" name="organotes"><?=htmlspecialchars($data["entry"]->organotes)?></textarea></td>
 </tr>
-<?
+<?php
 }
 add_hook("admin_editentry_editform","compobreakdown_editform");
 

--- a/www_admin/plugins/draggable_compoentries/ajax_reorder.php
+++ b/www_admin/plugins/draggable_compoentries/ajax_reorder.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("../../bootstrap.inc.php");
 
 $lock = new OpLock();
@@ -18,7 +18,7 @@ $entries = SQLLib::selectRows(sprintf_esc("select * from compoentries where comp
 $SUFFIX = ".\$tmp\$/";
 
 $compo = get_compo($_POST["compo"]);
-_rename($settings["private_ftp_dir"] . "/" . $compo->dirname, $settings["private_ftp_dir"] . "/" . $compo->dirname . $SUFFIX);  
+_rename($settings["private_ftp_dir"] . "/" . $compo->dirname, $settings["private_ftp_dir"] . "/" . $compo->dirname . $SUFFIX);
 
 $list = array();
 foreach($entries as $entry)
@@ -33,7 +33,7 @@ foreach($entries as $entry)
   }
 }
 
-// step2: move entries back by correct order 
+// step2: move entries back by correct order
 
 @mkdir( get_compo_dir( $compo ) );
 @chmod( get_compo_dir( $compo ), 0777 );
@@ -58,7 +58,7 @@ foreach($newOrder as $entryID)
   $newroot = get_compo_dir( $compo );
   $olddir = $oldroot.sprintf("_%03d",$entryID);
   $newdir = $newroot.sprintf("%03d",$n);
-  
+
   // if it was deleted since, just skip it
   if (file_exists($olddir))
   {

--- a/www_admin/plugins/draggable_compoentries/options.php
+++ b/www_admin/plugins/draggable_compoentries/options.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR") || !defined("PLUGINOPTIONS"))
   exit();
 

--- a/www_admin/plugins/draggable_compoentries/plugin.php
+++ b/www_admin/plugins/draggable_compoentries/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Draggable compo entries
 Description: Allows you to re-order your compo entries by drag-and-drop

--- a/www_admin/plugins/entryfeedback.php
+++ b/www_admin/plugins/entryfeedback.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Entry feedback
 Description: Allows the admin to respond to an entry for the user
@@ -22,7 +22,7 @@ function entryfeedback_editform( $data )
   <td>Organizer comment / response / feedback</td>
   <td><textarea id="organizerfeedback" name="organizerfeedback"><?=htmlspecialchars($data["entry"]->organizerfeedback)?></textarea></td>
 </tr>
-<?
+<?php
 }
 add_hook("admin_editentry_editform","entryfeedback_editform");
 

--- a/www_admin/plugins/entrystatus.php
+++ b/www_admin/plugins/entrystatus.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Entry status
 Description: Enables a variety of statuses for an entry (qualified, disqualified, etc.)
@@ -65,7 +65,7 @@ function entrystatus_addhead()
 .entrystatus:hover { opacity:0.5; }
 .entrystatus.selected { opacity:1.0; }
 </style>
-<?
+<?php
 }
 
 add_hook("admin_head","entrystatus_addhead");
@@ -73,7 +73,7 @@ add_hook("admin_head","entrystatus_addhead");
 function entrystatus_filterquery( $data )
 {
   global $ENTRYSTATUSACCEPTED;
-  
+
   $a = array();
   foreach($ENTRYSTATUSACCEPTED as $v) $a[] = sprintf_esc("status = '%s'",$v);
   $data["query"]->AddWhere("(".implode(" or ",$a).")");
@@ -152,9 +152,9 @@ function entrystatus_resetstatus( $data )
 {
   if (is_admin_page()) // only reset if user updates
     return;
-    
+
   $id = $data["entryID"];
- 
+
   SQLLib::Query(sprintf_esc("update compoentries set status = 'new' where id = %d",$id));
 }
 

--- a/www_admin/plugins/entrystatus.php
+++ b/www_admin/plugins/entrystatus.php
@@ -105,7 +105,7 @@ function entrystatus_activation()
   if (!$r)
   {
     global $ENTRYSTATUSFIELDS;
-    $fields = implode(",",array_map(create_function('$a',"return \"'\".\$a.\"'\";"),array_keys($ENTRYSTATUSFIELDS)));
+    $fields = implode(",",array_map(function($a) { return "'".$a."'"; },array_keys($ENTRYSTATUSFIELDS)));
     reset($ENTRYSTATUSFIELDS);
     SQLLib::Query("ALTER TABLE compoentries ADD `status` ENUM(".$fields.") NOT NULL DEFAULT '".key($ENTRYSTATUSFIELDS)."';");
   }

--- a/www_admin/plugins/filename-from-title.php
+++ b/www_admin/plugins/filename-from-title.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Rename files to "title by author.ext"
 */
@@ -7,7 +7,7 @@ if (!defined("ADMIN_DIR")) exit();
 function filenamefromtitle_rename( $data )
 {
   $extension = pathinfo($data["filename"],PATHINFO_EXTENSION);
-  
+
   $data["filename"] = $data["data"]["title"] . " by " . $data["data"]["author"] . "." . $extension;
 }
 

--- a/www_admin/plugins/imagegallery.php
+++ b/www_admin/plugins/imagegallery.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Image gallery
 */
@@ -12,13 +12,13 @@ function ig_replace($m)
 function imagegallery_content( $data )
 {
   $content = &$data["content"];
-  
+
   if (get_page_title() != "ImageGallery") return;
 
   ob_start();
   include_once(WWW_DIR . "/include_vote.php");
   $content = ob_get_clean();
-  
+
   $content = "<h2>Image Gallery</h2>\n\n".$content;
   $content = preg_replace_callback("/href=['\"].*Vote.*['\"]/i","ig_replace",$content);
   $content = preg_replace("/<div id='votesubmit'>.*<\/div>/i","",$content);

--- a/www_admin/plugins/lipsum/options.php
+++ b/www_admin/plugins/lipsum/options.php
@@ -47,7 +47,7 @@ function lipsum_delete_all_compos()
   {
     $dirname = get_compo_dir($compo);
 
-    rmdir($dirname);
+    @rmdir($dirname);
   }
   SQLLib::Query("truncate compos;");
 }
@@ -89,6 +89,8 @@ if ($_POST["fill"])
         "nickname" => $name,
         "password" => hashPassword($name),
         "group" => lipsum_string(10),
+        "regtime" => date("Y-m-d H:i:s",time() - rand(60*60,5*60*60)),
+        "regip" => long2ip(rand(0, "4294967295")),
       ));
     }
     printf("<div class='success'>Generated 5 new users</div>");
@@ -144,6 +146,7 @@ if ($_POST["fill"])
         "comment" => lipsum_string(140),
         "localFileName" => $tmp,
         "originalFileName" => basename($tmp),
+        "orgacomment" => "",
       ), $output))
       {
         printf("<div class='error'>".$output["error"]."</div>");

--- a/www_admin/plugins/lipsum/options.php
+++ b/www_admin/plugins/lipsum/options.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("PLUGINOPTIONS")) exit();
 
 function lipsum_string( $length = 10 )
@@ -32,7 +32,7 @@ function lipsum_delete_all_entries()
   {
     $dirname = get_compoentry_dir_path($entry);
     if (!$dirname) die("Error while getting compo entry dir");
-    
+
     $a = glob($dirname."*");
     foreach ($a as $v)
       unlink($v);
@@ -75,7 +75,7 @@ if ($_POST["truncate"])
     SQLLib::Query("update votekeys set userid = 0");
     SQLLib::Query("truncate users;");
     printf("<div class='success'>Deleted all users</div>");
-  }  
+  }
 }
 if ($_POST["fill"])
 {

--- a/www_admin/plugins/lipsum/plugin.php
+++ b/www_admin/plugins/lipsum/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Lorem Ipsum
 Description: The ability to fill your database with junk compos / entries / etc. for testing.

--- a/www_admin/plugins/livevote/options.php
+++ b/www_admin/plugins/livevote/options.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR") || !defined("PLUGINOPTIONS"))
   exit();
 
@@ -38,7 +38,7 @@ if ($compo)
   $query->AddOrder("playingorder");
   run_hook("admin_beamer_generate_compodisplay_dbquery",array("query"=>&$query));
   $entries = SQLLib::selectRows( $query->GetQuery() );
-  
+
   echo "<h2>"._html($compo->name)."</h2>";
 //  echo "<label>Select the entries to enable voting for them:</label>";
   echo "<ol id='entries'>";
@@ -71,11 +71,11 @@ document.observe("dom:loaded",function(){
         parameters:p,
         onSuccess:function(){ $("loading").update("") },
       });
-    });    
+    });
   });
 });
 //-->
 </script>
-<? if($compo && !$compo->votingopen) { ?>
+<?php if($compo && !$compo->votingopen) { ?>
 <p>Click <a href='./compos.php?id=<?=$compo->id?>&change=votingopen'>here</a> to enable normal voting for this compo.</p>
-<? } ?>
+<?php } ?>

--- a/www_admin/plugins/livevote/plugin.php
+++ b/www_admin/plugins/livevote/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Live voting
 */
@@ -7,7 +7,7 @@ if (!defined("ADMIN_DIR")) exit();
 function livevote_content( $data )
 {
   $content = &$data["content"];
-  
+
   if (get_page_title() != "LiveVote") return;
   if (!is_user_logged_in()) return;
   if (get_setting("voting_type") != "range") { $content = "Livevoting only works with ranged voting!"; return; }
@@ -35,7 +35,7 @@ function livevote_content( $data )
       }
     }
     die( json_encode($a) );
-  }  
+  }
   if ($_POST["listCompo"])
   {
     header("Content-type: application/json; charset=utf-8");
@@ -51,7 +51,7 @@ function livevote_content( $data )
       $a["compoName"] = $compo->name;
       $a["compoID"] = $compo->id;
       $a["csrf"] = $csrf->GenerateTokens();
-      
+
       $s = new SQLSelect();
       $s->AddField("compoentries.id");
       $s->AddField("compoentries.title");
@@ -68,7 +68,7 @@ function livevote_content( $data )
       $s->AddOrder("playingorder desc");
       $a["entries"] = SQLLib::selectRows($s->GetQuery());
     }
-    
+
     die( json_encode($a) );
   }
   $content = "<div id='livevoteContainer'></div>";
@@ -91,7 +91,7 @@ function reloadVotes()
     onSuccess:function(transport){
       if (!transport.responseJSON)
         return;
-      
+
       if (transport.responseJSON.error)
       {
         $("compoEntries").update("");
@@ -123,7 +123,7 @@ function reloadVotes()
               p[ "vote["+transport.responseJSON.compoID+"]["+entry.playingorder+"]" ] = ev.element().getAttribute("data-votevalue");
               p[ "ProtName" ] = csrfName;
               p[ "ProtValue" ] = csrfToken;
-              
+
               ev.element().addClassName("loading");
               new Ajax.Request(location.href,{
                 "method":"POST",
@@ -140,7 +140,7 @@ function reloadVotes()
                     ev.element().addClassName("selected");
                   }
                 },
-              });            
+              });
             });
             liEntry.down(".votes").insert( vote.update(i) );
           }
@@ -165,17 +165,17 @@ function reloadVotes()
 document.observe("dom:loaded",function(){
   var container = $("livevoteContainer");
   if (!container) return;
-  
+
   container.insert( new Element("h2",{"id":"compoName"}) );
   container.insert( new Element("ul",{"id":"compoEntries"}) );
-  
+
   reloadVotes();
   new PeriodicalExecuter(function(pe){ reloadVotes(); },15);
 });
 //-->
 </script>
 <noscript>Live voting requires JavaScript! (AMIGAAAAA!)</noscript>
-<?  
+<?php
   $content .= ob_get_clean();
 }
 add_hook("index_content","livevote_content");

--- a/www_admin/plugins/oneliner/functions.inc.php
+++ b/www_admin/plugins/oneliner/functions.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once(ADMIN_DIR . "/bootstrap.inc.php");
 
 function oneliner_allocate_color_from_setting( $img, $setting )
@@ -11,7 +11,7 @@ function oneliner_allocate_color_from_setting( $img, $setting )
 function oneliner_generate_png( $rows )
 {
   $plugindir = dirname(__FILE__);
-  
+
   $openfunc = Array(
     1 =>"imagecreatefromgif",
     2 =>"imagecreatefromjpeg",
@@ -23,30 +23,30 @@ function oneliner_generate_png( $rows )
   if (!$srcfile)
     list($srcfile) = glob(ADMIN_DIR . "/shared/background.*");
   $dstfile = ADMIN_DIR . "/slides/_oneliner.png";
-  
+
   $img = imagecreatefromstring( file_get_contents($srcfile) );
 
   $xSep = (int)get_setting("oneliner_xsep");
-  
+
   //$x = (int)get_setting("oneliner_bx1");
   $y = (int)get_setting("oneliner_by1");
 
   $colorNick = oneliner_allocate_color_from_setting( $img, "oneliner_nickcolor" );
   $colorText = oneliner_allocate_color_from_setting( $img, "oneliner_textcolor" );
   $size = (int)get_setting("oneliner_fontsize");
-  
+
   $lineSpac = (float)get_setting("oneliner_linespacing");
   foreach($rows as $row)
   {
     if ($y > (int)get_setting("oneliner_by2")) break;
-    
+
     $box = imageftbbox( $size, 0, $ttffile, $row->nickname, array( "linespacing" => $lineSpac ) );
     $width = $box[2] - $box[0];
-    
+
     $box = imagefttext( $img, $size, 0, $xSep - $width - 10, $y, $colorNick, $ttffile, $row->nickname, array( "linespacing" => $lineSpac ) );
 
     $text = mb_wordwrap($row->contents,(int)get_setting("oneliner_wordwrap"),"\n",1);
-    
+
     $box = imagefttext( $img, $size, 0, $xSep + 10, $y, $colorText, $ttffile, $text, array( "linespacing" => $lineSpac ) );
 
     $y += ($size + 10) * $lineSpac * (substr_count( $text, "\n" ) + 1) + 5;
@@ -81,7 +81,7 @@ function oneliner_generate_slide()
 {
   $rows = SQLLib::selectRows(
     "select oneliner.datetime, users.nickname, oneliner.contents from oneliner ".
-    "left join users on users.id = oneliner.userid order by datetime desc limit 20");  
+    "left join users on users.id = oneliner.userid order by datetime desc limit 20");
   if (!oneliner_generate_txt( $rows ))
     return "error writing slide file";
 

--- a/www_admin/plugins/oneliner/options.php
+++ b/www_admin/plugins/oneliner/options.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR") || !defined("PLUGINOPTIONS"))
   exit();
 
@@ -19,7 +19,7 @@ if($_GET["refresh"])
 
 $rows = SQLLib::selectRows(
   "select oneliner.datetime, users.nickname, users.id as uid, oneliner.contents from oneliner ".
-  "left join users on users.id = oneliner.userid order by datetime desc limit 10");  
+  "left join users on users.id = oneliner.userid order by datetime desc limit 10");
 
 printf("<a href='./slides/_oneliner.png'>See current slide</a> |\n");
 printf("<a href='%s&amp;refresh=1'>Re-generate slide</a>\n",$_SERVER["REQUEST_URI"]);
@@ -40,7 +40,7 @@ foreach($rows as $r)
 printf("</table>\n");
 ?>
 <h3>Crontab</h3>
-<?
+<?php
 $log = get_cron_log("oneliner_cron");
 if ($log)
 {
@@ -53,7 +53,7 @@ else
 //printf("<a href='./slides/_twitter.png'>See current slide</a> |\n");
 printf("<p><a href='%s&amp;refresh=1'>Re-generate slide manually</a></p>\n",$_SERVER["REQUEST_URI"]);
 ?>
-  
+
 <form action="<?=$_SERVER["REQUEST_URI"]?>" method="post">
   <h3>HTML rendering options</h3>
 
@@ -68,24 +68,24 @@ printf("<p><a href='%s&amp;refresh=1'>Re-generate slide manually</a></p>\n",$_SE
 
   <label for='oneliner_textcolor'>Message color:</label>
   <input type='text' id='oneliner_textcolor' name='oneliner_textcolor' value='<?=get_setting("oneliner_textcolor")?>'/>
-  
+
   <label for='oneliner_fontsize'>Font size:</label>
   <input type='number' id='oneliner_fontsize' name='oneliner_fontsize' value='<?=(int)get_setting("oneliner_fontsize")?>'/>
-  
+
   <label for='oneliner_by1'>Top border: (in pixels)</label>
   <input type='number' id='oneliner_by1' name='oneliner_by1' value='<?=(int)get_setting("oneliner_by1")?>'/>
-  
+
   <label for='oneliner_by2'>Bottom border: (in pixels)</label>
   <input type='number' id='oneliner_by2' name='oneliner_by2' value='<?=(int)get_setting("oneliner_by2")?>'/>
 
   <label for='oneliner_wordwrap'>Word wrapping: (in characters)</label>
   <input type='number' id='oneliner_wordwrap' name='oneliner_wordwrap' value='<?=(int)get_setting("oneliner_wordwrap")?>'/>
-  
+
   <label for='oneliner_xsep'>Nick width: (in pixels)</label>
   <input type='number' id='oneliner_xsep' name='oneliner_xsep' value='<?=(int)get_setting("oneliner_xsep")?>'/>
-  
+
   <label for='oneliner_linespacing'>Line spacing:</label>
   <input type='number' id='oneliner_linespacing' name='oneliner_linespacing' value='<?=(float)get_setting("oneliner_linespacing")?>'/>
--->  
+-->
   <input type="submit"/>
 </form>

--- a/www_admin/plugins/oneliner/plugin.php
+++ b/www_admin/plugins/oneliner/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Oneliner
 Description: Standard run-off-the-mill oneliner plugin. Note: use the {%ONELINER%} substitution token in your template!
@@ -10,14 +10,14 @@ function oneliner_parsepost( $data )
   if ($_POST["onelinerText"] && is_user_logged_in())
   {
     $valid = true;
-    
+
     //$row = SQLLib::selectRow(sprintf_esc("select id from compoentries where userID = %d limit 1",get_user_id()));
     //if (!$row) $valid = false;
-    
+
     $row = SQLLib::selectRow(sprintf_esc("select userID from oneliner order by datetime desc"));
     if ($row->userID == get_user_id())
       $valid = false;
-    
+
     if ($valid)
     {
       $a = array();
@@ -25,10 +25,10 @@ function oneliner_parsepost( $data )
       $a["contents"] = trim($_POST["onelinerText"]);
       $a["datetime"] = date("Y-m-d H:i:s");
       SQLLib::InsertRow("oneliner",$a);
-      
+
       oneliner_generate_slide();
     }
-    
+
     header("Location: ".$_SERVER["REQUEST_URI"]);
     exit();
   }
@@ -40,11 +40,11 @@ function oneliner_add_template_element( $data )
     //$TEMPLATE["{%ONELINER%}"] = "";
     //return;
   }
-  
+
   $rows = SQLLib::selectRows(
     "select oneliner.datetime, users.nickname, oneliner.contents from oneliner ".
-    "left join users on users.id = oneliner.userid order by datetime desc limit 10");  
-    
+    "left join users on users.id = oneliner.userid order by datetime desc limit 10");
+
   $s = "<div id='onelinercontainer'><h4>Funliner</h4>\n";
   if ($rows)
   {
@@ -73,7 +73,7 @@ function oneliner_add_template_element( $data )
     $s .= "<span class='not4u'>Log in to post!</span>\n";
   }
   $s .= "</div>\n";
-  
+
   $data["template"]["{%ONELINER%}"] = $s;
 }
 add_hook("index_template_elements","oneliner_parsepost");
@@ -107,7 +107,7 @@ function oneliner_activation()
     "  PRIMARY KEY (`id`)".
     ") ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;");
   }
-  
+
   if (get_setting("oneliner_nickcolor") === null)
     update_setting("oneliner_nickcolor","#000000");
   if (get_setting("oneliner_textcolor") === null)

--- a/www_admin/plugins/oneliner/refresh.php
+++ b/www_admin/plugins/oneliner/refresh.php
@@ -1,4 +1,4 @@
-<?
+<?php
 chdir(dirname(__FILE__));
 include_once("../../sqllib.inc.php");
 include_once("../../common.inc.php");

--- a/www_admin/plugins/scenesat-compodump.php
+++ b/www_admin/plugins/scenesat-compodump.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Scenesat preliminary compo entry list
 */
@@ -10,7 +10,7 @@ function compodump_content( $data )
   if (get_page_title() != "Compodump") return;
   $user = get_current_user_data();
   if ( !$user || !$user->compodump ) return;
-  
+
   $c = SQLLib::selectRows("select * from compos order by start,id");
   foreach($c as $compo) {
     $content .= "<h3>".htmlspecialchars($compo->name)."</h3>\n";
@@ -45,7 +45,7 @@ function compodump_addfield( &$data )
   User <b><?=$data["user"]->compodump?"can":"cannot"?></b> see compo dump
   <input type="submit" name="compodump_toggle" value="Toggle"/>
 </form>
-<?  
+<?php
 }
 add_hook("admin_edituser_beforeactions","compodump_addfield");
 

--- a/www_admin/plugins/single-page-voting.php
+++ b/www_admin/plugins/single-page-voting.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Single page voting
 Description: Separates the voting page by compos instead of one big list with all of them
@@ -8,10 +8,10 @@ if (!defined("ADMIN_DIR")) exit();
 function singlepagevoting_dbquery( $data )
 {
   $query = &$data["query"];
-  
+
   $compos = SQLLib::selectRows( $query->GetQuery() );
   if ($compos)
-  {  
+  {
     printf("<ul id='votecompolist'>\n");
     foreach($compos as $compo)
     {
@@ -19,11 +19,11 @@ function singlepagevoting_dbquery( $data )
     }
     printf("</ul>\n");
   }
-  else 
+  else
   {
     printf("No compos found open for voting!");
   }
-  
+
   if ($_GET["compo"])
     $query->AddWhere(sprintf_esc("id = %d",$_GET["compo"]));
   else

--- a/www_admin/plugins/timetable/options.php
+++ b/www_admin/plugins/timetable/options.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("PLUGINOPTIONS")) exit();
 
 $formdata = array(
@@ -28,10 +28,10 @@ $formdata = array(
       "format"=>"select",
       "grid"=>true,
       "fields"=>array(
-        'mainevent'=>"main event", 
-        'event'=>"event", 
-        'deadline'=>"deadline", 
-        'compo'=>"compo", 
+        'mainevent'=>"main event",
+        'event'=>"event",
+        'deadline'=>"deadline",
+        'compo'=>"compo",
         'seminar'=>"seminar"
       ),
     ),
@@ -86,7 +86,7 @@ else
     <input type="submit" name="export" value="Export!" />
   </div>
 </form>
-<?  
+<?php
 }
 
 

--- a/www_admin/plugins/timetable/plugin.php
+++ b/www_admin/plugins/timetable/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Timetable
 Description: Show your party schedule through the intranet
@@ -19,7 +19,7 @@ function get_timetable_content( $forceBreak = -1, $skipElapsed = false )
   $d = 0;
   $lastdate = -1;
   $lasttime = -1;
-  
+
   $rows = SQLLib::selectRows("select * from timetable order by `date`");
 
   $compos = SQLLib::selectRows("select * from compos order by start");
@@ -35,7 +35,7 @@ function get_timetable_content( $forceBreak = -1, $skipElapsed = false )
 
   $firstDay = 0;
   $counter = 0;
-  foreach($rows as $v) 
+  foreach($rows as $v)
   {
     if ($skipElapsed)
     {
@@ -43,13 +43,13 @@ function get_timetable_content( $forceBreak = -1, $skipElapsed = false )
         continue;
     }
     $day = date("l",strtotime($v->date));
-    
+
     // we don't do the check for the day-switch at midnight
     // instead we check at 4am, because it's visually more practical
     // iow "saturday 4am" still counts as friday
     $effectiveDay = date("l",strtotime($v->date) - 60 * 60 * 4);
 
-    if ($effectiveDay != $lastdate || ($forceBreak != -1 && $counter == $forceBreak)) 
+    if ($effectiveDay != $lastdate || ($forceBreak != -1 && $counter == $forceBreak))
     {
       if ($d++)
       {
@@ -121,7 +121,7 @@ function timetable_export()
   $n = 1;
   for ($x=0; $x<10; $x++)
     @unlink( sprintf(ADMIN_DIR . "/slides/timetable-%02d.htm",$x) );
-  
+
   foreach($a as $v)
   {
     if (strstr($v,"</h3>")===false)

--- a/www_admin/plugins/timetable/refresh.php
+++ b/www_admin/plugins/timetable/refresh.php
@@ -1,4 +1,4 @@
-<?
+<?php
 chdir(dirname(__FILE__));
 include_once("../../bootstrap.inc.php");
 include_once("plugin.php");
@@ -7,5 +7,5 @@ timetable_export();
 
 if (php_sapi_name() == "cli")
   echo date("Y-m-d H:i:s")."\n";
-  
+
 ?>

--- a/www_admin/plugins/twitter/options.php
+++ b/www_admin/plugins/twitter/options.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR") || !defined("PLUGINOPTIONS"))
   exit();
 
@@ -19,7 +19,7 @@ if($_GET["refresh"])
 
 ?>
 <h3>Crontab</h3>
-<?
+<?php
 $log = get_cron_log("twitter_cron");
 if ($log)
 {
@@ -58,25 +58,25 @@ printf("<p><a href='%s&amp;refresh=1'>Re-generate slide manually</a></p>\n",$_SE
 
   <label for='twitter_textcolor'>Message color:</label>
   <input type='text' id='twitter_textcolor' name='twitter_textcolor' value='<?=get_setting("twitter_textcolor")?>'/>
-  
+
   <label for='twitter_fontsize'>Font size:</label>
   <input type='number' id='twitter_fontsize' name='twitter_fontsize' value='<?=(int)get_setting("twitter_fontsize")?>'/>
-  
+
   <label for='twitter_bx1'>Left border: (in pixels)</label>
   <input type='number' id='twitter_bx1' name='twitter_bx1' value='<?=(int)get_setting("twitter_bx1")?>'/>
-  
+
   <label for='twitter_by1'>Top border: (in pixels)</label>
   <input type='number' id='twitter_by1' name='twitter_by1' value='<?=(int)get_setting("twitter_by1")?>'/>
-  
+
   <label for='twitter_by2'>Bottom border: (in pixels)</label>
   <input type='number' id='twitter_by2' name='twitter_by2' value='<?=(int)get_setting("twitter_by2")?>'/>
 
   <label for='twitter_wordwrap'>Word wrapping: (in characters)</label>
   <input type='number' id='twitter_wordwrap' name='twitter_wordwrap' value='<?=(int)get_setting("twitter_wordwrap")?>'/>
-  
+
   <label for='twitter_xsep'>Nick width: (in pixels)</label>
   <input type='number' id='twitter_xsep' name='twitter_xsep' value='<?=(int)get_setting("twitter_xsep")?>'/>
-  
+
   <label for='twitter_linespacing'>Line spacing:</label>
   <input type='number' id='twitter_linespacing' name='twitter_linespacing' value='<?=(float)get_setting("twitter_linespacing")?>'/>
 -->

--- a/www_admin/plugins/twitter/plugin.php
+++ b/www_admin/plugins/twitter/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Twitter feed
 Description: Standard run-of-the-mill twitter feed plugin.
@@ -45,7 +45,7 @@ function twitter_activation()
     update_setting("twitter_linespacing",0.9);
   if (get_setting("twitter_slidecount") === null)
     update_setting("twitter_slidecount",10);
-    
+
 
 }
 add_activation_hook( __FILE__, "twitter_activation" );

--- a/www_admin/plugins/twitter/refresh.php
+++ b/www_admin/plugins/twitter/refresh.php
@@ -1,4 +1,4 @@
-<?
+<?php
 chdir(dirname(__FILE__));
 include_once("../../sqllib.inc.php");
 include_once("functions.inc.php");
@@ -9,5 +9,5 @@ if (php_sapi_name() == "cli")
   echo date("Y-m-d H:i:s")."\n";
 else
   echo '<img src="../../slides/_twitter.png"/>';
-  
+
 ?>

--- a/www_admin/plugins/validate-archive.php
+++ b/www_admin/plugins/validate-archive.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Validate uploads as RAR/ZIP
 Description: Restricts the compo entry uploads to RAR or ZIP

--- a/www_admin/plugins/visitorlist.php
+++ b/www_admin/plugins/visitorlist.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Visitor list
 Description: Show registered visitors in the admin
@@ -9,7 +9,7 @@ function visitorlist_content( $data )
 {
   $content = &$data["content"];
   if (get_page_title() != "Visitors") return;
-  
+
   $content = "";
   $content .= sprintf("<h2>Visitors of the party</h2>\n");
   $content .= sprintf("<table id='visitors'>\n");
@@ -36,14 +36,14 @@ add_hook("register_processdata","visitorlist_processfield");
 function visitorlist_addfield( )
 {
   $checked = true;
-  if (is_user_logged_in()) 
+  if (is_user_logged_in())
     $checked = get_current_user_data()->visible;
 ?>
 <div>
   <label for="public">Do you want to appear on the visitors listing?</label>
   <input id="public" name="public" type="checkbox"<?=($checked?' checked="checked"':'')?>/>
 </div>
-<?
+<?php
 }
 add_hook("profile_endform","visitorlist_addfield");
 add_hook("register_endform","visitorlist_addfield");

--- a/www_admin/plugins/visitorlist.php
+++ b/www_admin/plugins/visitorlist.php
@@ -28,7 +28,7 @@ add_hook("index_content","visitorlist_content");
 
 function visitorlist_processfield( $data )
 {
-  $data["data"]["visible"] = $_POST["public"]=="on";
+  $data["data"]["visible"] = ($_POST["public"] == "on") ? 1 : 0;
 }
 add_hook("profile_processdata","visitorlist_processfield");
 add_hook("register_processdata","visitorlist_processfield");

--- a/www_admin/plugins/votestats/index.php
+++ b/www_admin/plugins/votestats/index.php
@@ -1,4 +1,4 @@
-<? include("../../bootstrap.inc.php"); ?>
+<?php include("../../bootstrap.inc.php"); ?>
 <!DOCTYPE html>
 <html>
 <head>
@@ -10,7 +10,7 @@
   </script>
 </head>
 <body>
-<?
+<?php
 $compos = SQLLib::selectRows("select id,name from compos order by start");
 foreach($compos as $compo)
 {
@@ -24,7 +24,7 @@ foreach($compos as $compo)
   $query->AddOrder("playingorder");
   run_hook("admin_results_dbquery",array("query"=>&$query));
   $entries = SQLLib::selectRows( $query->GetQuery() );
-  
+
 ?>
 <script type="text/javascript">
   function drawVisualization_1() {
@@ -32,7 +32,7 @@ foreach($compos as $compo)
   var data = new google.visualization.DataTable();
   data.addColumn('string', 'x');
   data.addColumn({type: 'string', role: 'annotation'});
-<?
+<?php
 foreach($entries as $entry)
   printf("data.addColumn('number', '%s - %s');\n",addslashes($entry->title),addslashes($entry->author));
 
@@ -47,12 +47,12 @@ $aggr = array();
 foreach($entries as $v) $aggr[$v->playingorder] = 0;
 foreach($score as $time => $chunk)
 {
-  foreach($chunk as $id=>$v) $aggr[$id] += $v;  
+  foreach($chunk as $id=>$v) $aggr[$id] += $v;
   $tstr = date("Y-m-d H:i:s",$time);
   $anno = "null";
   //if (strstr($tstr,"00:00:00")!==false) $anno = "'midnight'";
   //if (strstr($tstr,"00:35:00")!==false) $anno = "'approx. end of compos'";
-  
+
   printf("data.addRow([\"%s\", %s, %s]);\n",$tstr,$anno,implode(",",$aggr));
 }
 $last = $start;
@@ -77,7 +77,7 @@ $last = $start;
 google.setOnLoadCallback(drawVisualization_1);
 </script>
 <div id="visualization_<?=$compo->id?>"></div>
-<?  
+<?php
 }
 ?>
 </body>

--- a/www_admin/plugins/votestats/plugin.php
+++ b/www_admin/plugins/votestats/plugin.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /*
 Plugin name: Vote statistics
 Description: Over-time voting statistics on pretty looking graphs!

--- a/www_admin/results.php
+++ b/www_admin/results.php
@@ -1,14 +1,14 @@
-<?
+<?php
 include_once("header.inc.php");
 
 if($_POST["upload_to_sceneorg"] && $_POST["partyname"] && function_exists("ftp_connect"))
 {
   $_GET["encoding"] = "utf-8";
   $_GET["suppressHeader"] = true;
-  
+
   $partyname = $_POST["partyname"];
   sanitize_filename($partyname);
-  
+
   ob_start();
   include_once("results_text.php");
   $data = ob_get_clean();
@@ -18,7 +18,7 @@ if($_POST["upload_to_sceneorg"] && $_POST["partyname"] && function_exists("ftp_c
     $temp = fopen('php://temp', 'r+');
     fwrite($temp, $data);
     rewind($temp);
-    
+
     if (!($ftp = ftp_connect("ftp.scene.org"))) return "Unable to connect to scene.org";
     if (!ftp_login($ftp, "anonymous", "wuhu@upload")) return "Unable to login to scene .org";
     if (!ftp_pasv($ftp, true)) return "Unable to change to passive mode";
@@ -62,7 +62,7 @@ if (function_exists("ftp_connect"))
 echo "<h2>Results</h2>";
 
 $c = SQLLib::selectRows("select * from compos order by start,id");
-foreach($c as $compo) 
+foreach($c as $compo)
 {
   echo "<h3><a href='compos_entry_list.php?id=".$compo->id."'>".$compo->name."</a></h3>\n";
 
@@ -78,7 +78,7 @@ foreach($c as $compo)
   $results = $voter->CreateResultsFromVotes( $compo, $entries );
   run_hook("voting_resultscreated_presort",array("results"=>&$results));
   arsort($results);
-  
+
   $n = 1;
   echo "<table class='results'>\n";
   $lastPoints = -1;

--- a/www_admin/results_text.php
+++ b/www_admin/results_text.php
@@ -1,4 +1,4 @@
-<?
+<?php
 error_reporting(E_ALL ^ E_NOTICE);
 include_once("bootstrap.inc.php");
 
@@ -29,9 +29,9 @@ if (file_exists("results_header.txt"))
   include_once("results_header.txt");
 else
   echo "The [results_header.txt] file is missing, upload one to include a cool ASCII header!\n\n";
-  
+
 $c = SQLLib::selectRows("select * from compos order by start,id");
-foreach($c as $compo) 
+foreach($c as $compo)
 {
   printf("\n\n\n  %s\n\n",strtoupper($compo->name));
 
@@ -49,9 +49,9 @@ foreach($c as $compo)
   arsort($results);
   $n = 1;
   $lastpoints = -1;
-  
-  
-  foreach($results as $k=>$v) 
+
+
+  foreach($results as $k=>$v)
   {
     $e = SQLLib::selectRow(sprintf_esc("select * from compoentries where id = %d",$k));
     $title = sprintf("%s - %s",convertEncoding(trim($e->title)),convertEncoding(trim($e->author)));

--- a/www_admin/screenshot.php
+++ b/www_admin/screenshot.php
@@ -1,4 +1,4 @@
-<?
+<?php
 //error_reporting(E_ALL);
 session_start();
 include_once("database.inc.php");
@@ -9,13 +9,13 @@ if(!$s) exit;
 
 $a = $_GET["show"]=="thumb" ? get_compoentry_screenshot_thumb_path( $_GET["id"] ) : get_compoentry_screenshot_path( $_GET["id"] );
 
-if (file_exists($a)) 
+if (file_exists($a))
 {
   list($width,$height,$type) = getimagesize($a);
   header("Content-type: ".image_type_to_mime_type($type));
   echo @file_get_contents($a);
-} 
-else 
+}
+else
 {
   header("Content-type: image/png");
   if ($_GET["show"]=="thumb")
@@ -26,8 +26,8 @@ else
       thumbnail( ADMIN_DIR . "/noscreenshot.png",$path,$settings["screenshot_sizex"],$settings["screenshot_sizey"]);
     }
     echo file_get_contents($path);
-  } 
-  else 
+  }
+  else
   {
     echo file_get_contents( ADMIN_DIR . "/noscreenshot.png" );
   }

--- a/www_admin/setting.inc.php
+++ b/www_admin/setting.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 function load_settings()
 {
   global $settings;
@@ -21,7 +21,7 @@ function update_setting( $key, $value )
 {
   global $settings;
   $settings[$key] = $value;
-  
+
   $a = array();
   $a["setting"] = $key;
   $a["value"] = $value;

--- a/www_admin/settings.php
+++ b/www_admin/settings.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("header.inc.php");
 
 $formdata = array(

--- a/www_admin/slideeditor.php
+++ b/www_admin/slideeditor.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("header.inc.php");
 
 if (is_uploaded_file($_FILES["newSlideFile"]["tmp_name"]))
@@ -32,7 +32,7 @@ else if ($_POST["editSlideContents"] && $_POST["editSlideFilename"])
 else if ($_GET["delete"])
 {
   unlink("slides/".basename($_GET["delete"]));
-  
+
   header("Location: slideeditor.php");
   exit();
 }
@@ -69,7 +69,7 @@ else if ($_GET["edit"])
 else
 {
   $a = glob("slides/*");
-  
+
   echo "<h2>Current slides</h2>\n";
   echo "<ul id='slides'>\n";
   foreach($a as $v)
@@ -78,7 +78,7 @@ else
     if ($v == ".") continue;
     if ($v == "..") continue;
     if ($v == "index.php") continue;
-    
+
     echo "<li>\n";
     printf("<h3>%s</h3>\n",_html($v));
     printf("<div class='contents'>\n");
@@ -107,7 +107,7 @@ else
     echo "</li>";
   }
   echo "</ul>\n";
-  
+
   echo "<h2>Add new slides</h2>\n";
 
   echo "<form method='post' enctype='multipart/form-data'>\n";
@@ -124,7 +124,7 @@ else
   printf("<h3>Upload new slide</h3>\n");
   echo "<input type='file' name='newSlideFile' required='yes' />";
   echo "<input type='submit' value='Start upload' />";
-  
+
   echo "</form>\n";
   ?>
   <script type="text/javascript">
@@ -136,7 +136,7 @@ else
   });
   //-->
   </script>
-  <?
+  <?php
 }
 include_once("footer.inc.php");
 ?>

--- a/www_admin/slides/index.php
+++ b/www_admin/slides/index.php
@@ -1,4 +1,4 @@
-<?
+<?php
 $a = array();
 if ($_GET["allSlides"])
 {
@@ -17,7 +17,7 @@ list($path) = explode("?",$_SERVER["REQUEST_URI"]);
 $dir = ($_SERVER["HTTPS"]=="on"?"https":"http") . "://" . $_SERVER["SERVER_NAME"] . dirname($path . "/dummy.txt");
 if ($_GET["allSlides"])
   $dir = "../slides";
-  
+
 echo "<slides>\n";
 foreach ($a as $v) {
   if($v == ".") continue;

--- a/www_admin/slideviewer.php
+++ b/www_admin/slideviewer.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("header.inc.php");
 
 if ($_GET["saveDimensions"])
@@ -11,15 +11,15 @@ if ($_GET["saveDimensions"])
   <label>Native slide size:</label>
   <input type='number' name='width' value='<?=(get_setting("slideviewer_x") ?: "1920")?>' style='width: 70px'/> x
   <input type='number' name='height' value='<?=(get_setting("slideviewer_y") ?: "1080")?>' style='width: 70px'/>
-<!--  
+<!--
   <label>Fullscreen:</label>
   <input type='checkbox' name='fullscreen' checked='checked'/>
 -->
   <label>Prizegiving display style:</label>
   <div><input type='radio' name='newPrizegiving' value='true'/> New style (multiple entries are displayed on a page with a bar displaying the score <b>BETA, use at your own risk</b>)</div>
   <div><input type='radio' name='newPrizegiving' value='false' checked='checked'/> Old style (each entry gets it's own page</div>
-  
-  
+
+
   <input type="submit" value='Open viewer' style='display:block;margin-top:20px;'/>
 </form>
 
@@ -28,7 +28,7 @@ if ($_GET["saveDimensions"])
 </noscript>
 
 <h3>Keyboard shortcuts</h3>
-<ul>  
+<ul>
 <li>LEFT ARROW - previous slide</li>
 <li>RIGHT ARROW - next slide</li>
 <li>HOME - first slide</li>
@@ -53,7 +53,7 @@ document.observe("dom:loaded",function(){
     var wnd = window.open("./slideviewer/?" + hash, '', 'fullscreen=yes');
 
     if (false) // maybe one day this will not suck
-    {    
+    {
       var reqFS = [
         "requestFullscreen",
         "webkitRequestFullscreen",
@@ -75,7 +75,7 @@ document.observe("dom:loaded",function(){
 });
 //-->
 </script>
-<?
+<?php
 
 include_once("footer.inc.php");
 

--- a/www_admin/sqllib.inc.php
+++ b/www_admin/sqllib.inc.php
@@ -175,7 +175,6 @@ class SQLLib
       if ($v===NULL) {
         $set[] = sprintf("`%s`=null",mysqli_real_escape_string(SQLLib::$link,$k));
       } else {
-        if (is_bool($v)) $v = $v ? 1 : 0;
         $set[] = sprintf("`%s`='%s'",mysqli_real_escape_string(SQLLib::$link,$k),mysqli_real_escape_string(SQLLib::$link,$v));
       }
     }

--- a/www_admin/sqllib.inc.php
+++ b/www_admin/sqllib.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 global $SQLLIB_QUERIES;
 $SQLLIB_QUERIES = array();
 

--- a/www_admin/sqllib.inc.php
+++ b/www_admin/sqllib.inc.php
@@ -361,11 +361,9 @@ class SQLSelect
 function sprintf_esc()
 {
   $args = func_get_args();
-  reset($args);
-  next($args);
-  while (list($key, $value) = each($args))
-    $args[$key] = mysqli_real_escape_string( SQLLib::$link, $args[$key] );
-
+  for ($key = 1; $key < count($args); $key++) {
+    $args[$key] = mysqli_real_escape_string(SQLLib::$link, $args[$key]);
+  }
   return call_user_func_array("sprintf", $args);
 }
 

--- a/www_admin/sqllib.inc.php
+++ b/www_admin/sqllib.inc.php
@@ -172,12 +172,10 @@ class SQLLib
     else if (is_array($o)) $a = $o;
     $set = Array();
     foreach($a as $k=>$v) {
-      if ($v===NULL)
-      {
+      if ($v===NULL) {
         $set[] = sprintf("`%s`=null",mysqli_real_escape_string(SQLLib::$link,$k));
-      }
-      else
-      {
+      } else {
+        if (is_bool($v)) $v = $v ? 1 : 0;
         $set[] = sprintf("`%s`='%s'",mysqli_real_escape_string(SQLLib::$link,$k),mysqli_real_escape_string(SQLLib::$link,$v));
       }
     }

--- a/www_admin/thumbnail.inc.php
+++ b/www_admin/thumbnail.inc.php
@@ -1,22 +1,22 @@
-<?
-function thumbnail_shrink($srcfile, $dstfile, $limitx=128,$limity=128) 
+<?php
+function thumbnail_shrink($srcfile, $dstfile, $limitx=128,$limity=128)
 {
   list($x,$y,$type,$attr) = GetImageSize($srcfile);
   if ($x<=$limitx && $y<=$limity) {
     copy($srcfile, $dstfile);
     return;
   }
-  
+
   $big = $x>$y ? $x : $y;
   $newx = floor($x*$limitx/$big);
   $newy = floor($y*$limity/$big);
-  
+
   $openfunc = Array(
     1 =>"imagecreatefromgif",
     2 =>"imagecreatefromjpeg",
     3 =>"imagecreatefrompng",
   );
-  
+
   $src = $openfunc[$type]($srcfile);
   $dst = imagecreatetruecolor($newx, $newy);
 
@@ -29,30 +29,30 @@ function thumbnail_shrink($srcfile, $dstfile, $limitx=128,$limity=128)
   flush();
 }
 
-function thumbnail_crop($srcfile, $dstfile, $limitx=128,$limity=128) 
+function thumbnail_crop($srcfile, $dstfile, $limitx=128,$limity=128)
 {
   list($x,$y,$type,$attr) = GetImageSize($srcfile);
-  
+
   $aspThmb = $limitx / (float)$limity;
   $aspOrig = $x / (float)$y;
 
-  /* 
+  /*
     this might need some explanation:
-    
+
     we need to decide if the aspect ratios of the two pictures are the same.
-    
+
     aspect ratios are the same when they're both on the same side of 1,
     i.e. they're both smaller than 1 (portrait) or both bigger than 1 (landscape)
-    
+
     so we do this by subtracting 1 from each (causing portrait ratios to be negative)
     and multiplying them: if only one of them is negative, the result will be < 0
-    
+
     if one of them is square (1), we assume they're not the same aspect.
-    
+
     we could probably optimize one more branch but meh.
   */
 
-  if (($aspThmb - 1) * ($aspOrig - 1) <= 0) 
+  if (($aspThmb - 1) * ($aspOrig - 1) <= 0)
   {
     // aspects/orientation are different
     if ($aspThmb > $aspOrig)
@@ -60,7 +60,7 @@ function thumbnail_crop($srcfile, $dstfile, $limitx=128,$limity=128)
       $cropx = $x;
       $cropy = floor($x * $limity / $limitx);
     }
-    else 
+    else
     {
       $cropx = floor($y * $limitx / $limity);
       $cropy = $y;
@@ -74,19 +74,19 @@ function thumbnail_crop($srcfile, $dstfile, $limitx=128,$limity=128)
       $cropx = floor($y * $limitx / $limity);
       $cropy = $y;
     }
-    else 
+    else
     {
       $cropx = $x;
       $cropy = floor($x * $limity / $limitx);
     }
   }
-  
+
   $openfunc = Array(
     1 =>"imagecreatefromgif",
     2 =>"imagecreatefromjpeg",
     3 =>"imagecreatefrompng",
   );
-  
+
   $src = $openfunc[$type]($srcfile);
   $dst = imagecreatetruecolor($limitx, $limity);
 
@@ -99,7 +99,7 @@ function thumbnail_crop($srcfile, $dstfile, $limitx=128,$limity=128)
   flush();
 }
 
-function thumbnail($srcfile, $dstfile, $limitx=128,$limity=128) 
+function thumbnail($srcfile, $dstfile, $limitx=128,$limity=128)
 {
   return thumbnail_crop($srcfile, $dstfile, $limitx, $limity);
 }

--- a/www_admin/toc.php
+++ b/www_admin/toc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("header.inc.php");
 
 $rows = SQLLib::selectRows("select title from intranet_minuswiki_pages");

--- a/www_admin/users.php
+++ b/www_admin/users.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("header.inc.php");
 
 run_hook("admin_edituser_start");
@@ -21,16 +21,16 @@ if ($_GET["id"]) {
   printf("<h2>Users - ".htmlspecialchars($user->username)."</h2>");
 
   $votekey = SQLLib::selectRow(sprintf_esc("select * from votekeys where userid = %d",(int)$_GET["id"]));
-  
-  printf("<ul>");  
-  printf("  <li><b>Nick:</b> %s</li>\n",htmlspecialchars($user->nickname));  
-  printf("  <li><b>Group:</b> %s</li>\n",htmlspecialchars($user->group));  
-  printf("  <li><b>Public:</b> %s</li>\n",$user->visible?"yes":"no");  
-  printf("  <li><b>IP:</b> %s</li>\n",$user->regip);  
-  printf("  <li><b>Registration time:</b> %s</li>\n",$user->regtime);  
+
+  printf("<ul>");
+  printf("  <li><b>Nick:</b> %s</li>\n",htmlspecialchars($user->nickname));
+  printf("  <li><b>Group:</b> %s</li>\n",htmlspecialchars($user->group));
+  printf("  <li><b>Public:</b> %s</li>\n",$user->visible?"yes":"no");
+  printf("  <li><b>IP:</b> %s</li>\n",$user->regip);
+  printf("  <li><b>Registration time:</b> %s</li>\n",$user->regtime);
   if ($votekey)
-    printf("  <li><b>Associated votekey:</b> %s</li>\n",$votekey->votekey);  
-  printf("</ul>");  
+    printf("  <li><b>Associated votekey:</b> %s</li>\n",$votekey->votekey);
+  printf("</ul>");
 
 echo "<hr/>\n";
 
@@ -46,7 +46,7 @@ $entries = SQLLib::selectRows(sprintf_esc("select *,compoentries.id as id from c
   <th>File name</th>
   <th>File size</th>
 </tr>
-<?
+<?php
 $n = 1;
 foreach($entries as $t) {
   printf("<tr>\n");
@@ -77,8 +77,8 @@ run_hook("admin_edituser_beforeactions",array("user"=>$user));
   <input type="password" name="newpassword" />
   <input type="submit" name="action" value="Set new password"/>
 </form>
-<?
-  
+<?php
+
 } else {
   printf("<h2>Users</h2>");
   printf("<table class='minuswiki'>");
@@ -94,23 +94,23 @@ run_hook("admin_edituser_beforeactions",array("user"=>$user));
         $sq = "select count(*) from votes_preferential where votes_preferential.userid = u.id";
       } break;
   }
-  
+
   $s = SQLLib::selectRows("select *, ".
      " (".$sq.") as votes, ".
      " (select count(*) from compoentries where compoentries.userid = u.id) as entries ".
      " from users as u order by regtime");
   foreach($s as $t) {
-    printf("<tr>");  
-    printf("  <td>%d.</td>",$n++);  
-    printf("  <td>#%d</td>",$t->id);  
+    printf("<tr>");
+    printf("  <td>%d.</td>",$n++);
+    printf("  <td>#%d</td>",$t->id);
     printf("  <td><a href='users.php?id=%d'>%s</a></td>",$t->id,htmlspecialchars($t->username));
-    printf("  <td>%s</td>",htmlspecialchars($t->nickname));  
-    printf("  <td>%s</td>",htmlspecialchars($t->group));  
-  //  printf("  <td>%s</td>",$t->regip);  
-    printf("  <td>%s</td>",htmlspecialchars($t->regtime));  
-    printf("  <td>%d votes</td>",htmlspecialchars($t->votes));  
-    printf("  <td>%d entries</td>",htmlspecialchars($t->entries));  
-    printf("</tr>");  
+    printf("  <td>%s</td>",htmlspecialchars($t->nickname));
+    printf("  <td>%s</td>",htmlspecialchars($t->group));
+  //  printf("  <td>%s</td>",$t->regip);
+    printf("  <td>%s</td>",htmlspecialchars($t->regtime));
+    printf("  <td>%d votes</td>",htmlspecialchars($t->votes));
+    printf("  <td>%d entries</td>",htmlspecialchars($t->entries));
+    printf("</tr>");
   }
   printf("</table>");
 }

--- a/www_admin/votekeys.php
+++ b/www_admin/votekeys.php
@@ -1,37 +1,37 @@
-<?
+<?php
 include_once("header.inc.php");
 
-if ($_POST["votekeys_format"]) 
+if ($_POST["votekeys_format"])
 {
   update_setting("votekeys_format",$_POST["votekeys_format"]);
 }
-if ($_POST["votekeys_css"]) 
+if ($_POST["votekeys_css"])
 {
   update_setting("votekeys_css",$_POST["votekeys_css"]);
 }
-if ($_POST["amount"]) 
+if ($_POST["amount"])
 {
   SQLLib::Query("truncate votekeys");
   $len = (int)$_POST["length"] ? (int)$_POST["length"] : 8;
-  
+
   $abc = str_split("BCDFGHJKLMNPQRSTVWXYZ");
-  for($x=0; $x<$_POST["amount"]; $x++) 
+  for($x=0; $x<$_POST["amount"]; $x++)
   {
     $str = "";
     for ($y=0; $y<$len; $y++)
       $str .= $abc[ array_rand($abc) ];
-    
+
     $hash = strtoupper($_POST["prefix"].$str);
     SQLLib::InsertRow("votekeys",array("votekey"=>$hash));
   }
 }
-if ($_POST["mode"] && is_uploaded_file($_FILES["votekeyfile"]["tmp_name"])) 
+if ($_POST["mode"] && is_uploaded_file($_FILES["votekeyfile"]["tmp_name"]))
 {
   if ($_POST["mode"] == "reset")
   {
     SQLLib::Query("truncate votekeys");
   }
-  
+
   $f = file( $_FILES["votekeyfile"]["tmp_name"] );
   foreach($f as $v)
   {
@@ -45,7 +45,7 @@ if ($_POST["mode"] && is_uploaded_file($_FILES["votekeyfile"]["tmp_name"]))
       } catch(Exception $e) {}
     }
   }
-  
+
 }
 
 ?>
@@ -56,7 +56,7 @@ if ($_POST["mode"] && is_uploaded_file($_FILES["votekeyfile"]["tmp_name"]))
 <form action="votekeys.php" method="post" enctype="multipart/form-data" id='votekeys_print'>
   <label>Votekey format (HTML, <b>{%VOTEKEY%}</b> will be substituted):</label>
   <textarea name="votekeys_format"><?=_html($settings["votekeys_format"] ?: "{%VOTEKEY%}")?></textarea>
-  <label>Additional print CSS:</label> 
+  <label>Additional print CSS:</label>
   <textarea name="votekeys_css"><?=_html($settings["votekeys_css"] ?: "")?></textarea>
   <input type="submit" value="Save"/>
 </form>
@@ -71,7 +71,7 @@ if ($_POST["mode"] && is_uploaded_file($_FILES["votekeyfile"]["tmp_name"]))
 <h3>Load votekeys from text file</h3>
 <form action="votekeys.php" method="post" enctype="multipart/form-data">
   <label>File:</label> <input type="file" name="votekeyfile"/>
-  <label>Usage:</label> 
+  <label>Usage:</label>
   <div>
     <input type="radio" name="mode" value="reset" id='load1' /> <label for='load1'>Replace existing</label>
     <input type="radio" name="mode" value="merge" id='load2' checked='checked' /> <label for='load2'>Merge with existing</label>
@@ -79,7 +79,7 @@ if ($_POST["mode"] && is_uploaded_file($_FILES["votekeyfile"]["tmp_name"]))
   <input type="submit" value="Upload!"/>
 </form>
 <h3>Current votekeys</h3>
-<?
+<?php
 printf("<table class='minuswiki' id='votekeys'>");
 $n = 1;
 $count = SQLLib::selectRow("select count(*) as c from votekeys where userid!=0")->c;
@@ -87,11 +87,11 @@ printf("<tr><td colspan='3'>%d votekeys used</td></tr>\n",$count);
 
 $s = SQLLib::selectRows("select * from votekeys");
 foreach($s as $t) {
-  printf("<tr>");  
-  printf("  <td>%d.</td>",$n++);  
-  printf("  <td class='key'>%s</td>",$t->votekey);  
-  printf("  <td>%s</td>",$t->userid?sprintf("<a href='users.php?id=%d'>used</a>",$t->userid):"");  
-  printf("</tr>");  
+  printf("<tr>");
+  printf("  <td>%d.</td>",$n++);
+  printf("  <td class='key'>%s</td>",$t->votekey);
+  printf("  <td>%s</td>",$t->userid?sprintf("<a href='users.php?id=%d'>used</a>",$t->userid):"");
+  printf("</tr>");
 }
 printf("</table>");
 

--- a/www_admin/votekeys_print.php
+++ b/www_admin/votekeys_print.php
@@ -1,4 +1,4 @@
-<?
+<?php
 include_once("bootstrap.inc.php");
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
@@ -36,7 +36,7 @@ li {
 </style>
 </head>
 <body>
-<?
+<?php
 printf("<ul class='votekeys'>");
 $n = 1;
 $s = SQLLib::selectRows("select * from votekeys");

--- a/www_admin/votesystem.inc.php
+++ b/www_admin/votesystem.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 abstract class Vote
 {
   abstract public function CreateResultsFromVotes( $compo, $entries ); /* returns associative array (entryid => score) */

--- a/www_party/.gitignore
+++ b/www_party/.gitignore
@@ -1,0 +1,3 @@
+database.inc.php
+prototype.js
+template.html

--- a/www_party/include_entries.php
+++ b/www_party/include_entries.php
@@ -1,8 +1,8 @@
-<?
+<?php
 if (!defined("ADMIN_DIR")) exit();
 
 global $settings;
-function perform(&$msg) 
+function perform(&$msg)
 {
   global $settings;
   if (!is_user_logged_in()) {
@@ -25,7 +25,7 @@ function perform(&$msg)
 
   $msg = $out["error"];
   return 0;
-} 
+}
 if ($_POST["entryid"]) {
   $msg = "";
   $id = perform($msg);
@@ -40,12 +40,12 @@ if ($_GET["id"]) {
   $entry = SQLLib::selectRow(sprintf_esc("select * from compoentries where id=%d",$_GET["id"]));
   if ($entry->userid != $_SESSION["logindata"]->id)
     die("nice try.");
-    
+
   $compo = get_compo($entry->compoid);
 
   $filedir = get_compoentry_dir_path( $entry );
   if (!$filedir)
-    die("Unable to find compo entry dir!");    
+    die("Unable to find compo entry dir!");
 
   if ($_GET["select"]) {
     $lock = new OpLock();
@@ -97,15 +97,15 @@ if ($_GET["id"]) {
 <div class='formrow'>
   <label>Uploaded files</label>
 <table id='uploadedfiles'>
-<?
+<?php
   $a = glob($filedir . "*");
-  foreach ($a as $v) 
+  foreach ($a as $v)
   {
     $v = basename($v);
 ?>
 <tr class='<?=($v == $entry->filename?"fileselected":"fileunselected")?>'>
   <td><?=$v?></td>
-  <td><?
+  <td><?php
   if ($v == $entry->filename) {
     echo "<i>Currently selected file</i>";
   } else {
@@ -114,7 +114,7 @@ if ($_GET["id"]) {
   }
   ?></td>
 </tr>
-<?
+<?php
   }
 ?>
 </table>
@@ -124,9 +124,9 @@ if ($_GET["id"]) {
     <small>(max. <?=ini_get("upload_max_filesize")?> - if you want to upload
   a bigger file, just upload a dummy text file here and ask the organizers!)</small></label>
   <input name="entryfile" type="file" />
-<?if (count($a)>1) {?>
+<?php if (count($a)>1) { ?>
   <small id='multifilewarning'>(Hint: having only <u>ONE</u> file decreases the chances of having the wrong version played!)</small>
-<?}?>
+<?php } ?>
 </div>
 <div class='formrow'>
   <input name="entryid" type='hidden' value="<?=(int)$_GET["id"]?>" />
@@ -134,24 +134,24 @@ if ($_GET["id"]) {
 </div>
 </div>
 </form>
-<?
+<?php
 } else {
   $entries = SQLLib::selectRows(sprintf_esc("select * from compoentries where userid=%d",get_user_id()));
   echo "<div class='entrylist' id='editmyentries'>\n";
   global $entry;
-  foreach ($entries as $entry) 
+  foreach ($entries as $entry)
   {
     $compo = get_compo( $entry->compoid );
     echo "<div class='entry'>\n";
     printf("<div class='screenshot'><a href='screenshot.php?id=%d' target='_blank'><img src='screenshot.php?id=%d&amp;show=thumb'/></a></div>\n",$entry->id,$entry->id);
     printf("<div class='compo'>%s</div>\n",_html($compo->name));
     printf("<div class='title'><b>%s</b> - %s</div>\n",_html($entry->title),_html($entry->author));
-    
+
     if ($compo->uploadopen || $compo->updateopen)
       printf("<div class='editlink'><a href='%s&amp;id=%d'>Edit entry</a></div>",$_SERVER["REQUEST_URI"],$entry->id );
-      
+
     run_hook("editentries_endrow",array("entry"=>$entry));
-    
+
     echo "</div>\n";
   }
   echo "</div>";

--- a/www_party/include_login.php
+++ b/www_party/include_login.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR")) exit();
 
 if (is_user_logged_in())
@@ -9,20 +9,20 @@ if (is_user_logged_in())
 
 run_hook("login_start");
 
-if ($_POST["login"]) 
+if ($_POST["login"])
 {
   $_SESSION["logindata"] = NULL;
-  
+
   $userID = SQLLib::selectRow(sprintf_esc("select id from users where `username`='%s' and `password`='%s'",$_POST["login"],hashPassword($_POST["password"])))->id;
 
   run_hook("login_authenticate",array("userID"=>&$userID));
-  
-  if ($userID) 
+
+  if ($userID)
   {
     $_SESSION["logindata"] = SQLLib::selectRow(sprintf_esc("select * from users where id=%d",$userID));
     header( "Location: ".build_url("News",array("login"=>"success")) );
-  } 
-  else 
+  }
+  else
   {
     header( "Location: ".build_url("Login",array("login"=>"failure")) );
   }
@@ -44,6 +44,6 @@ if ($_GET["login"]=="failure")
   <input type="submit" value="Go!" />
 </div>
 </form>
-<?
+<?php
 run_hook("login_end");
 ?>

--- a/www_party/include_logout.php
+++ b/www_party/include_logout.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR")) exit();
 
 $_SESSION["logindata"] = array();

--- a/www_party/include_news.php
+++ b/www_party/include_news.php
@@ -1,14 +1,14 @@
-<?
+<?php
 if (!defined("ADMIN_DIR")) exit();
 ?>
 <dl id='news'>
-<?
+<?php
 $news = SQLLib::selectRows("select * from intranet_news order by `date` desc");
 foreach($news as $n) {
 ?>
 <dt><?=date("Y-m-d",strtotime($n->date))?> - <?=_html($n->eng_title)?></dt>
 <dd><?=$n->eng_body?></dd>
-<?
+<?php
 }
 ?>
 </dl>

--- a/www_party/include_profile.php
+++ b/www_party/include_profile.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR")) exit();
 
 if ($_POST["nickname"]) {
@@ -16,7 +16,7 @@ if ($_POST["nickname"]) {
       $userdata["password"] = hashPassword($_POST["password"]);
     }
   }
-  SQLLib::UpdateRow("users",$userdata,sprintf_esc("id='%d'",get_user_id()));    
+  SQLLib::UpdateRow("users",$userdata,sprintf_esc("id='%d'",get_user_id()));
   echo "<div class='success'>Profile editing successful!</div>";
 }
 global $user;
@@ -45,7 +45,7 @@ global $page;
   <label for="group">Group: (if any)</label>
   <input name="group" type="text" id="group" value="<?=_html($user->group)?>"/>
 </div>
-<?
+<?php
 run_hook("profile_endform");
 ?>
 <div id='regsubmit'>

--- a/www_party/include_register.php
+++ b/www_party/include_register.php
@@ -1,61 +1,61 @@
-<?
+<?php
 if (!defined("ADMIN_DIR")) exit();
 
 run_hook("register_start");
 
 function validate() {
-  if (strlen($_POST["username"])<3) 
+  if (strlen($_POST["username"])<3)
   {
     echo "<div class='error'>This username is too short, must be at least 4 characters!</div>";
     return 0;
   }
-  if (strlen($_POST["password"])<4) 
+  if (strlen($_POST["password"])<4)
   {
     echo "<div class='error'>This password is too short, must be at least 4 characters!</div>";
     return 0;
   }
-  if (!preg_match("/^[a-zA-Z0-9]{3,}$/",$_POST["username"])) 
+  if (!preg_match("/^[a-zA-Z0-9]{3,}$/",$_POST["username"]))
   {
     echo "<div class='error'>This username contains invalid characters!</div>";
     return 0;
   }
   /*
-  if (!preg_match("/^[a-zA-Z0-9]{4,}$/",$_POST["password"])) 
+  if (!preg_match("/^[a-zA-Z0-9]{4,}$/",$_POST["password"]))
   {
     echo "<div class='error'>This password contains invalid characters!</div>";
     return 0;
   }
   */
-    if (strcmp($_POST["password"],$_POST["password2"])!=0) 
+    if (strcmp($_POST["password"],$_POST["password2"])!=0)
     {
     echo "<div class='error'>Passwords don't match!</div>";
     return 0;
   }
-  
+
   $r = SQLLib::selectRows(sprintf_esc("select * from users where `username`='%s'",$_POST["username"]));
-  if ($r) 
+  if ($r)
   {
     echo "<div class='error'>This username is already taken!</div>";
     return 0;
   }
-  
+
   $r = SQLLib::selectRow(sprintf_esc("select * from votekeys where `votekey`='%s'",$_POST["votekey"]));
-  if (!$r) 
+  if (!$r)
   {
     echo "<div class='error'>This votekey is invalid!</div>";
     return 0;
   }
-  if ($r->userid) 
+  if ($r->userid)
   {
     echo "<div class='error'>This votekey is already in use!</div>";
     return 0;
-  } 
-  
+  }
+
   return 1;
 }
 $success = false;
 if ($_POST["username"]) {
-  if (validate()) 
+  if (validate())
   {
     $userdata = array(
       "username"=> ($_POST["username"]),
@@ -70,12 +70,12 @@ if ($_POST["username"]) {
     if (!$error)
     {
       $trans = new SQLTrans();
-      $userID = SQLLib::InsertRow("users",$userdata);    
+      $userID = SQLLib::InsertRow("users",$userdata);
       SQLLib::UpdateRow("votekeys",array("userid"=>$userID),sprintf_esc("`votekey`='%s'",$_POST["votekey"]));
       echo "<div class='success'>Registration successful!</div>";
       $success = true;
-    } 
-    else 
+    }
+    else
     {
       echo "<div class='failure'>"._html($error)."</div>";
     }
@@ -109,14 +109,14 @@ if(!$success)
   <label for="group">Group: (if any)</label>
   <input id="group" name="group" type="text" value="<?=_html($_POST["group"])?>"/>
 </div>
-<?
+<?php
 run_hook("register_endform");
 ?>
 <div id='regsubmit'>
   <input type="submit" value="Go!" />
 </div>
 </form>
-<?
+<?php
 }
 
 run_hook("register_end");

--- a/www_party/include_upload.php
+++ b/www_party/include_upload.php
@@ -1,10 +1,10 @@
-<?
+<?php
 if (!defined("ADMIN_DIR")) exit();
 
 global $settings;
 include_once(ADMIN_DIR . "/thumbnail.inc.php");
 
-function perform(&$msg) 
+function perform(&$msg)
 {
   global $settings;
   if (!is_user_logged_in()) {
@@ -26,7 +26,7 @@ function perform(&$msg)
 
   $msg = $out["error"];
   return 0;
-} 
+}
 if ($_POST) {
   $msg = "";
   $id = perform($msg);
@@ -47,10 +47,10 @@ global $page;
   <label for='compo'>Compo:</label>
   <select id='compo' name="compo" required='yes'>
     <option value=''>-- Please select a compo:</option>
-<?
+<?php
 foreach($s as $t)
   printf("  <option value='%d'%s>%s</option>\n",$t->id,$t->id==$_POST["compo"] ? ' selected="selected"' : "",$t->name);
-?>  
+?>
   </select>
 </div>
 <div class='formrow'>
@@ -86,6 +86,6 @@ foreach($s as $t)
 </div>
 </div>
 </form>
-<?
+<?php
 } else echo "Sorry, all deadlines are closed!";
 ?>

--- a/www_party/include_vote.php
+++ b/www_party/include_vote.php
@@ -1,4 +1,4 @@
-<?
+<?php
 if (!defined("ADMIN_DIR")) exit();
 
 $voter = SpawnVotingSystem();
@@ -8,7 +8,7 @@ if (!$voter)
 
 $csrf = new CSRFProtect();
 
-if ($_POST["vote"]) 
+if ($_POST["vote"])
 {
   $a = array();
   if ($csrf->ValidateToken())
@@ -16,7 +16,7 @@ if ($_POST["vote"])
     if ($voter->SaveVotes())
     {
       echo "<div class='success'>Votes saved!</div>";
-    } 
+    }
     else
     {
       echo "<div class='failure'>There was an error saving your votes!</div>";
@@ -36,12 +36,12 @@ $query->AddOrder("start");
 run_hook("vote_prepare_dbquery",array("query"=>&$query));
 $compos = SQLLib::selectRows( $query->GetQuery() );
 
-if ($compos) 
+if ($compos)
 {
   echo "<form id='votingform' action='".$_SERVER['REQUEST_URI']."' method='post' enctype='multipart/form-data'>\n";
   $csrf->PrintToken();
-  
-  foreach($compos as $compo) 
+
+  foreach($compos as $compo)
   {
     global $query;
     $query = new SQLSelect();
@@ -50,24 +50,24 @@ if ($compos)
     $query->AddOrder("playingorder");
     run_hook("vote_compo_dbquery",array("query"=>&$query));
     $entries = SQLLib::selectRows( $query->GetQuery() );
-    
-    if ($entries) 
+
+    if ($entries)
     {
       printf("<h3>%s</h3>\n",$compo->name);
       echo "<div class='entrylist votelist'>\n";
 
       $voter->PrepareVotes( $compo );
-     
-      foreach($entries as $entry) 
+
+      foreach($entries as $entry)
       {
         echo "<div class='entry'>\n";
         printf("<div class='screenshot'><a href='screenshot.php?id=%d' target='_blank'><img src='screenshot.php?id=%d&amp;show=thumb'/></a></div>\n",$entry->id,$entry->id);
-        
+
         if($compo->showauthor)
           printf("<div class='title'><b>%s</b> - %s</div>\n",_html($entry->title),_html($entry->author));
         else
           printf("<div class='title'><b>%s</b></div>\n",_html($entry->title));
-          
+
         printf("<div class='vote'>\n");
         $voter->RenderVoteGUI( $compo, $entry );
         printf("</div>\n");
@@ -78,7 +78,7 @@ if ($compos)
   }
   echo "<div id='votesubmit'><input type='submit' value='Submit votes!'/></div>\n";
   echo "</form>\n";
-} 
+}
 
 
 ?>

--- a/www_party/minuswiki.inc.php
+++ b/www_party/minuswiki.inc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 class MinusWiki
 {
   var $PageTitle;
@@ -9,7 +9,7 @@ class MinusWiki
     $this->PageTitle = $get["page"];
     list($this->CurrentLanguageCode) = explode(":",$this->PageTitle);
   }
-  
+
   function RetrievePage($pagename) {
     $row = SQLLib::SelectRow(sprintf_esc("select * from %s where title='%s' limit 1",$this->TableName,$pagename));
     return $row->content;
@@ -57,10 +57,10 @@ class MinusWiki
     $link = rawurlencode($link);
     $link = str_replace("%3A",":",$link);
     $link = str_replace("%23","#",$link);
-    
+
     return sprintf("<a href='/index.php?page=%s'>%s</a>",$link,$text);
   }
-  
+
   var $linkNum = 1;
   function ExternalLinkCallback($matches) {
     $text = $matches[1];
@@ -68,10 +68,10 @@ class MinusWiki
       list($link,$text) = explode(" ",$text,2);
       $link = str_replace("&","&amp;",$link);
       return sprintf("<a href='%s' target='_blank' class='external'>%s</a>",$link,$text);
-    } else   
+    } else
       return sprintf("<a href='%s' target='_blank' class='external'>[%d]</a>",$text,$this->linkNum++);
   }
-  
+
   function IncludeCallback($matches) {
     $text = $matches[1];
     if(strstr($text,":")) {
@@ -124,8 +124,8 @@ class MinusWiki
       $this->inDIV = 0;
     }
     return $output;
-  }  
-  
+  }
+
   function ParsePage($text) {
     $lines = explode("\n",$text);
     $output = "";
@@ -136,13 +136,13 @@ class MinusWiki
       // non-paragraphic
       if (strpos($l,"=")===0) {
         $output .= $this->InsertClosingTags();
-        $l = preg_replace("/====(.*)====/","<h4>$1</h4>",$l);      
-        $l = preg_replace("/===(.*)===/","<h3>$1</h3>",$l);      
-        $l = preg_replace("/==(.*)==/","<h2>$1</h2>",$l);      
-        $l = preg_replace("/=(.*)=/","<h1>$1</h1>",$l);      
+        $l = preg_replace("/====(.*)====/","<h4>$1</h4>",$l);
+        $l = preg_replace("/===(.*)===/","<h3>$1</h3>",$l);
+        $l = preg_replace("/==(.*)==/","<h2>$1</h2>",$l);
+        $l = preg_replace("/=(.*)=/","<h1>$1</h1>",$l);
         preg_match("/>(.*)</",$l,$m);
         $l = "<a name='".str_replace(" ","_",$m[1])."'></a>\n".$l;
-      } 
+      }
       else if (strpos($l,"*")===0) {
         //$output.="#".$l."#";
         $output .= $this->InsertClosingTags("ul");
@@ -186,9 +186,9 @@ class MinusWiki
           $output .= "<p>\n";
           $this->inParagraph = 1;
         }
-        
+
       }
-      
+
       /////////////////////////////////////////
       // paragraphic
       if (strstr($l,"[[")!==FALSE) {
@@ -199,12 +199,12 @@ class MinusWiki
       }
       if (strstr($l,"{{")!==FALSE) {
         $l = preg_replace_callback("/\{\{(.*?)\}\}/",array(&$this,"IncludeCallback"),$l);
-      } 
+      }
       if (strstr($l,"''")!==FALSE) {
         $l = preg_replace("/'''(.*?)'''/","<b>$1</b>",$l);
         $l = preg_replace("/''(.*?)''/","<i>$1</i>",$l);
       }
-      
+
       $output .= $l."\n";
     }
     if ($this->inParagraph) {
@@ -214,15 +214,15 @@ class MinusWiki
     $output .= $this->InsertClosingTags("");
     return $output;
   }
-  
+
   function GetPage($pagename) {
     $pagename = str_replace("_"," ",$pagename);
     $data = $this->RetrievePage($pagename);
     if (!$data)
       return "<b>Sorry!</b> No page titled '<i>".htmlentities($pagename)."</i>' found!";
-      
+
     $parseddata = $this->ParsePage($data);
-    
+
     return $parseddata;
   }
 };

--- a/www_party/screenshot.php
+++ b/www_party/screenshot.php
@@ -1,4 +1,4 @@
-<?
+<?php
 session_start();
 include_once("database.inc.php");
 include_once(ADMIN_DIR . "/bootstrap.inc.php");


### PR DESCRIPTION
- Replaced all "`<?`" with "`<?php`" except "`<?=`" which is always available since PHP 5.4.0. _(Default behavior for PHP > 7.0.0)_
- Replaced `each` function with a `for` loop. _(Deprecated since PHP 7.2.0)_
- Silence `file_get_contents`, if file doesn't exists
- Replace `define`/`defined` to take string as argument
- Silence `rmdir` & add default values for `regtime`, `regip` & `orgacomment` for lipsum plugin
- Add `.gitignore` for generated files