### PR TITLE
Export votekeys in text or JSON format

### DIFF
--- a/www_admin/votekeys.php
+++ b/www_admin/votekeys.php
@@ -89,6 +89,10 @@ if ($_POST["mode"] && is_uploaded_file($_FILES["votekeyfile"]["tmp_name"]))
   </div>
   <input type="submit" value="Upload!"/>
 </form>
+
+<h3>Export votekeys</h3>
+<p>Text format: <a href='votekeys_text.php'>view</a> / <a href='votekeys_text.php?filename=votekeys.txt'>download</a></p>
+<p>JSON format: <a href='votekeys_text.php?format=json'>view</a> / <a href='votekeys_text.php?format=json&amp;filename=votekeys.json'>download</a></p>
 <h3>Current votekeys</h3>
 <?php
 printf("<table class='minuswiki' id='votekeys'>");

--- a/www_admin/votekeys_text.php
+++ b/www_admin/votekeys_text.php
@@ -1,0 +1,29 @@
+<?php
+error_reporting(E_ALL ^ E_NOTICE);
+include_once("bootstrap.inc.php");
+
+$encoding = "iso-8859-1";
+if (!$_GET["suppressHeader"])
+{
+  header("Content-Type: text/plain; charset=".$encoding);
+  if ($_GET["filename"])
+    header("Content-disposition: attachment; filename=".$_GET["filename"]);
+}
+
+$s = SQLLib::selectRows("select * from votekeys");
+
+$format = $_GET["format"] ?? "text";
+if ($format == "json")
+{
+  $json = [ "votekeys" => [] ];
+  foreach($s as $t) {
+    $json["votekeys"][] = $t->votekey;
+  }
+  echo json_encode($json);
+}
+else
+{
+  foreach($s as $t) {
+    printf("%s\n",$t->votekey);
+  }
+}


### PR DESCRIPTION
While Wuhu has support for importing votekeys (and printing), it currently does not have any method to export votekeys. 
 For our purposes, we've found using Wuhu's votekey generation to be useful, but we needed a way to make use of the votekeys with other applications.

This is a simple feature addition to allow votekeys to be viewed or downloaded as either plaintext or JSON from the Votekeys page in the Admin panel.

<img width="316" alt="Screen Shot 2021-10-31 at 15 28 16" src="https://user-images.githubusercontent.com/532282/139571496-eeab5a7b-e026-4877-8f89-bccfc5f4ba17.png">

For reference, the exported JSON is formatted as a single array of strings, like so:
```
{ "votekeys": [ "VOTEKEY-TFPTDPYL", ... ] }
```