### PR TITLE
Revert some changes that break Function orga workflow

### DIFF
--- a/www_admin/common.inc.php
+++ b/www_admin/common.inc.php
@@ -270,7 +270,9 @@ function handleUploadedRelease( $dataArray, &$output )
     }
 
     @mkdir($settings["private_ftp_dir"] . "/" . $compo->dirname);
+    @chmod($settings["private_ftp_dir"] . "/" . $compo->dirname, 0777);
     @mkdir($settings["private_ftp_dir"] . "/" . $compo->dirname . "/" . sprintf("%03d",$order));
+    @chmod($settings["private_ftp_dir"] . "/" . $compo->dirname . "/" . sprintf("%03d",$order), 0777);
 
     $sqldata["filename"] = $filenameBase;
     $output["filename"] = $filenameBase;

--- a/www_admin/common.inc.php
+++ b/www_admin/common.inc.php
@@ -269,7 +269,8 @@ function handleUploadedRelease( $dataArray, &$output )
       $filenamePath = $settings["private_ftp_dir"] . "/" . $compo->dirname . "/" . sprintf("%03d",$order) . "/" . $filenameBase;
     }
 
-    @mkdir($settings["private_ftp_dir"] . "/" . $compo->dirname . "/" . sprintf("%03d",$order), 0777, True);
+    @mkdir($settings["private_ftp_dir"] . "/" . $compo->dirname);
+    @mkdir($settings["private_ftp_dir"] . "/" . $compo->dirname . "/" . sprintf("%03d",$order));
 
     $sqldata["filename"] = $filenameBase;
     $output["filename"] = $filenameBase;


### PR DESCRIPTION
This PR reverts some changes by @kusma, that broke our Function compo workflow. 

The recursive `mkdir()` call with 0777 permission doesn't equal the explicit `mkdir()` and `chmod()` pairs, because in the original case, the `umask` for the process is ignored for the explicit `chmod()` while in the "new" code version, `mkdir()`'s permission is modified by the `umask`. So the directories were in fact created with `755` mask, and that interfered with direct file manipulation by the orga user via SCP/SFTP. (For example the upload of large video files associated with the entires.)

I was too lazy to figure out how to make sure the `umask` is the right one for all cases, so I just reverted the two commits for now that broke it for our workflow. Feel free to advise and tell us what we're holding wrong, or provide a better version rather than reverting.