### PR TITLE
fix slideviewer requiring result.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Both beam systems rely on simple keypresses for operation.
 * END - last slide
 * S - partyslide rotation mode
 * T - reload stylesheet (without changing the slide contents) 
-* SPACE - re-read result.xml (and quit partyslide mode)
+* SPACE - re-read beamer.data (and quit partyslide mode)
     
 This last key essentially means that once you've used the "BEAMER" menu on the admin interface, you must press SPACE to refresh the data inside (and/or switch to another mode).
   

--- a/www_admin/index.php
+++ b/www_admin/index.php
@@ -29,7 +29,7 @@ function todo_createcompos()     { return SQLLib::selectRow("select * from compo
 function todo_generatevotekeys() { return SQLLib::selectRow("select * from votekeys limit 1"); }
 function todo_createtemplate()   { return file_exists( WWW_DIR . "/template.html" ); }
 function todo_replaceascii()     { return file_exists( ADMIN_DIR . "/results_header.txt" ); }
-function todo_resultxml()        { return file_exists( ADMIN_DIR . "/result.xml" ); }
+function todo_beamerdata()       { return file_exists( ADMIN_DIR . "/beamer.data" ); }
 function todo_slideviewercss()   { return file_exists( ADMIN_DIR . "/slideviewer/custom.css" ); }
 function todo_crontab()          { return SQLLib::selectRow("select * from cron"); }
 
@@ -38,7 +38,7 @@ $checks = array(
   "todo_generatevotekeys" => "Generate <a href='votekeys.php'>votekeys</a> and print them",
   "todo_createtemplate" => "Create a template.html for the party intranet",
   "todo_replaceascii" => "Replace the <a href='results_text.php'>results file header</a>",
-  "todo_resultxml" => "Generate an XML for <a href='beamer.php'>the beamer</a>",
+  "todo_beamerdata" => "Generate data for <a href='beamer.php'>the beamer</a>",
   "todo_slideviewercss" => "Create a custom.css for <a href='slideviewer.php'>the slide viewer</a>",
 );
 if (has_cron())

--- a/www_admin/slideviewer.php
+++ b/www_admin/slideviewer.php
@@ -10,7 +10,7 @@ if (@$_GET["saveDimensions"])
 
 <h2>Open slideviewer</h2>
 
-<?php if (file_exists("result.xml")){ ?>
+<?php if (file_exists("beamer.data")){ ?>
 <form action="/slideviewer/" method="get" id="frm">
   <label>Native slide size:</label>
   <input type='number' name='width' value='<?=(get_setting("slideviewer_x") ?: "1920")?>' style='width: 70px'/> x
@@ -41,7 +41,7 @@ if (@$_GET["saveDimensions"])
 <li>DOWN ARROW - minus one minute in countdown mode</li>
 <li>S - partyslide rotation mode</li>
 <li>T - reload stylesheet without changing the slide</li>
-<li>SPACE - re-read result.xml (and quit partyslide mode)</li>
+<li>SPACE - re-read beamer.data (and quit partyslide mode)</li>
 </ul>
 <?php }else{ ?>
   <p>You haven't set a slide mode yet; go <a href="beamer.php">here</a> to do so.</p>


### PR DESCRIPTION
Hi,

While setting things up for this year's party I noticed that I got stuck on "You haven't set a slide mode yet; go here to do so." on the slideviewer page.

I took a quick look in the source and saw that it was gated behind `file_exists("result.xml")`, which I'm guessing is something that was missed during the changes in 02dae1c8329028ee6ffdceb45117e5caff797a90? So I did some search and replace and then everything seemed to run smoothly again.