### PR TITLE
slideviewer: fix unofficial pause feature and make it official

### DIFF
--- a/www_admin/slideviewer.php
+++ b/www_admin/slideviewer.php
@@ -40,6 +40,7 @@ if (@$_GET["saveDimensions"])
 <li>UP ARROW - plus one minute in countdown mode</li>
 <li>DOWN ARROW - minus one minute in countdown mode</li>
 <li>S - partyslide rotation mode</li>
+<li>P - pause / unpause partyslide rotation</li>
 <li>T - reload stylesheet without changing the slide</li>
 <li>SPACE - re-read beamer.data (and quit partyslide mode)</li>
 </ul>

--- a/www_admin/slideviewer/wuhu.js
+++ b/www_admin/slideviewer/wuhu.js
@@ -447,7 +447,7 @@ var WuhuSlideSystem = Class.create({
 
       var wuhu = this;
       new PeriodicalExecuter((function(pe) {
-        if (this.slideMode == this.MODE_ROTATION)
+        if (this.slideMode == this.MODE_ROTATION && Reveal.isAutoSliding())
         {
           this.fetchSlideRotation();
         }


### PR DESCRIPTION
Caveat: while paused, the slide rotation isn't updated automatically, but that's most likely the intended behavior anyway.

This required a mild change to reveal.js to make the current pause status available. The old way didn't work, because Reveal's internal member variables aren't exposed in the public interface, only the methods are.