### PR TITLE
Timetable: fix missing time in slides

### DIFF
--- a/www_admin/plugins/timetable/plugin.php
+++ b/www_admin/plugins/timetable/plugin.php
@@ -84,6 +84,7 @@ function get_timetable_content_html( $forceBreak = -1, $skipElapsed = false )
       $counter = 0;
       $hasTable = true;
       $lastdate = $effectiveDay;
+      $lasttime = -1;
     }
 
     $content .= sprintf("<tr%s>\n",$elapsed ? " class='elapsed'" : "");


### PR DESCRIPTION
When exporting slides from the Timetable plugin, if there is a page break and the first event of the new page has the same time as the last event of the previous page, the time on the new page was missing. This fixes that.